### PR TITLE
Add copyright header to files

### DIFF
--- a/pyswmm/__init__.py
+++ b/pyswmm/__init__.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014 Bryant E. McDonnell
+#
+# Licensed under the terms of the BSD2 License
+# See LICENSE.txt for details
+# -----------------------------------------------------------------------------
+"""Python Wrapper for Stormwater Management Model (SWMM5)."""
+
+
 __author__ = 'Bryant E. McDonnell (EmNet LLC) - bemcdonnell@gmail.com'
 __copyright__ = 'Copyright (c) 2016 Bryant E. McDonnell'
 __licence__ = 'BSD2'

--- a/pyswmm/links.py
+++ b/pyswmm/links.py
@@ -1,3 +1,12 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014 Bryant E. McDonnell
+#
+# Licensed under the terms of the BSD2 License
+# See LICENSE.txt for details
+# -----------------------------------------------------------------------------
+"""Links module for the pythonic interface to SWMM5."""
+
 from toolkitapi import *
 from swmm5 import SWMMException, PYSWMMException
 

--- a/pyswmm/pyswmm.py
+++ b/pyswmm/pyswmm.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014 Bryant E. McDonnell
+#
+# Licensed under the terms of the BSD2 License
+# See LICENSE.txt for details
+# -----------------------------------------------------------------------------
 """Base class for a SWMM Simulation."""
 
 from swmm5 import PySWMM

--- a/pyswmm/swmm5.py
+++ b/pyswmm/swmm5.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014 Bryant E. McDonnell
+#
+# Licensed under the terms of the BSD2 License
+# See LICENSE.txt for details
+# -----------------------------------------------------------------------------
 """
 Python extensions for the SWMM5 Programmers toolkit
 

--- a/pyswmm/toolkitapi.py
+++ b/pyswmm/toolkitapi.py
@@ -1,7 +1,11 @@
-
-'''
-SWMM Object Enum
-'''
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014 Bryant E. McDonnell
+#
+# Licensed under the terms of the BSD2 License
+# See LICENSE.txt for details
+# -----------------------------------------------------------------------------
+"""SWMM Object Enum."""
 
 
 class SimulationTime:    


### PR DESCRIPTION
Fixes #21 

@bemcdonnell, I added the normal copyright notice, which normally requires only the date of start, I assumed 2014, but please let me know if the date is different.

I also included the UTF header which is also a standard practice.

Comments?