### PR TITLE
PR: Add code style automatic checks on appveyor

### DIFF
--- a/.ciocheck
+++ b/.ciocheck
@@ -1,0 +1,112 @@
+# -----------------------------------------------------------------------------
+# ciocheck
+# https://github.com/ContinuumIO/ciocheck
+# -----------------------------------------------------------------------------
+[ciocheck]
+branch = origin/master
+diff_mode = commited
+file_mode = all
+check = pep8,pydocstyle,flake8,isort,yapf,coverage,pytest
+enforce = pep8,pydocstyle,flake8,isort,yapf
+
+# Python (pyformat)
+add_copyright = true
+add_header = true
+add_init = true
+
+# -----------------------------------------------------------------------------
+# pep8
+# http://pep8.readthedocs.io/en/latest/intro.html#configuration
+# -----------------------------------------------------------------------------
+[pep8]
+exclude = */tests/*,*/external/*
+ignore = E126,
+max-line-length = 79
+
+# -----------------------------------------------------------------------------
+# pydocstyle
+# http://www.pydocstyle.org/en/latest/usage.html#example
+# -----------------------------------------------------------------------------
+[pydocstyle]
+add-ignore = D203
+inherit = false
+match = '(?!github.py)'
+
+# -----------------------------------------------------------------------------
+# Flake 8
+# http://flake8.readthedocs.io/en/latest/config.html
+# -----------------------------------------------------------------------------
+[flake8]
+exclude = */tests/*,*/external/*
+ignore = E126,
+max-line-length = 79
+max-complexity = 64
+
+# -----------------------------------------------------------------------------
+# pylint
+# https://pylint.readthedocs.io/en/latest/
+# -----------------------------------------------------------------------------
+#[pylint:messages]
+
+# -----------------------------------------------------------------------------
+# isort
+# https://github.com/timothycrosley/isort/wiki/isort-Settings
+# -----------------------------------------------------------------------------
+[isort]
+from_first = true
+import_heading_stdlib = Standard library imports
+import_heading_firstparty = Local imports
+import_heading_thirdparty = Third party imports
+indent = '    '
+known_first_party = pyswmm
+known_third_party = setuptools
+known_standard_library = mimetypes, enum
+line_length = 79
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+
+# -----------------------------------------------------------------------------
+# yapf
+# https://github.com/google/yapf#formatting-style
+# -----------------------------------------------------------------------------
+[yapf:style]
+based_on_style = pep8
+column_limit = 79
+spaces_before_comment = 2
+
+# -----------------------------------------------------------------------------
+# autopep8
+# http://pep8.readthedocs.io/en/latest/intro.html#configuration
+# -----------------------------------------------------------------------------
+[autopep8]
+exclude =
+    */tests/*
+    */external/*
+ignore = E126,
+max-line-length = 79
+
+# -----------------------------------------------------------------------------
+# Coverage
+# http://coverage.readthedocs.io/en/latest/config.html
+# -----------------------------------------------------------------------------
+[coverage:run]
+omit =
+    */tests/*
+    */build/*
+    */external/*
+
+[coverage:report]
+fail_under = 0
+show_missing = true
+skip_covered = true
+exclude_lines =
+    pragma: no cover
+    def test():
+    if __name__ == .__main__.:
+
+# -----------------------------------------------------------------------------
+# pytest
+# http://doc.pytest.org/en/latest/usage.html
+# -----------------------------------------------------------------------------
+[pytest]
+addopts = -rfew --durations=10
+python_functions = test_*

--- a/.ciocheck
+++ b/.ciocheck
@@ -6,8 +6,8 @@
 branch = origin/master
 diff_mode = commited
 file_mode = all
-check = pep8,pydocstyle,flake8,isort,yapf,coverage,pytest
-enforce = pep8,pydocstyle,flake8,isort,yapf
+check = pydocstyle,flake8,isort,yapf,coverage,pytest
+enforce = pydocstyle,flake8,isort,yapf
 
 # Python (pyformat)
 add_copyright = true

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+omit = 
+	*/tests/*
+	*/build/*
+	*/external/*
+
+[report]
+fail_under = 0
+show_missing = true
+skip_covered = true
+exclude_lines = 
+	pragma: no cover
+	def test():
+	if __name__ == .__main__.:
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,28 @@
+# Compiled python files
+*.py[oc]
 
-# Python stuff
-__pycache__/
-*.pyc
-*.out
-*.ini
-*.rpt
-*.mp4
-*.chi
-*.CSV
-*.thm
+# gedit files
+*~
+
+# kate files
+.directory
+
+# Python special dirs and files
+*.egg-info
+*.cache/
+*.coverage
+build/
+dist/
+bin/
+
+# OS files
+Thumbs.db
+.DS_Store/
+.DS_Store
+
+# git files
+*.orig
+
+# Changelog generator
+CHANGELOG.temp
+labels.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,33 +1,45 @@
-build: false
+# https://ci.appveyor.com/project/goanpeca/pyswmm
+
+matrix:
+  fast_finish: true
+
+branches:
+  only:
+    - master 
 
 environment:
+  global:
+    # Used by qthelpers to close widgets after a defined time
+    TEST_CI: True
+    # Environment variables used by astropy helpers
+    PYTHON: "C:\\conda"
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
+    PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
+                      # of 32 bit and 64 bit builds are needed, move this
+                      # to the matrix section.
+
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.8"
-      PYTHON_ARCH: "32"
+    - PYTHON_VERSION: "3.6"
+    - PYTHON_VERSION: "3.5"
+    - PYTHON_VERSION: "2.7"
 
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.9"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.10"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.11"
-      PYTHON_ARCH: "32"
-      
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.12"
-      PYTHON_ARCH: "32"      
-      
-init:
-  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+platform:
+  -x64
 
 install:
-  - "%PYTHON%/Scripts/pip.exe install nose"
-  - "%PYTHON%/Scripts/pip.exe install coverage"
+  # Astropy ci-helpers. See https://github.com/astropy/ci-helpers
+  - "git clone git://github.com/astropy/ci-helpers.git"
+  - "powershell ci-helpers/appveyor/install-miniconda.ps1"
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "activate test"
+  # Install the selected Qt version
+  - "conda install --file requirements.txt -c spyder-ide"
+  - "if($env:PYTHON_VERSION -eq 2.7) {conda install enum34}"
+  - "python setup.py develop"
+
+# Not a .NET project, we build in the install step instead
+build: false
 
 test_script:
-  - "%PYTHON%/Scripts/nosetests"
+  - ciocheck setup.py --disable-tests
+  - ciocheck pyswmm --disable-tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
   - "activate test"
   # Install the selected Qt version
   - "conda install --file requirements.txt -c spyder-ide"
-  - "if($env:PYTHON_VERSION -eq 2.7) {conda install enum34}"
+  - IF "%PYTHON_VERSION%" == "2.7" conda install enum34
   - "python setup.py develop"
 
 # Not a .NET project, we build in the install step instead

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,40 @@
+# https://circleci.com/gh/OpenWaterAnalytics/pyswmm/
+
+machine:
+  environment:
+    # Used by qthelpers to close widgets after a defined time
+    TEST_CI:          "True"
+    # Python versions to tests (Maximum of 4 different versions)
+    PY_VERSIONS:      "3.6 3.5 2.7"
+    # Environment variables used by astropy helpers
+    TRAVIS_OS_NAME:   "linux"
+    # Conda variables and aliases for commands
+    CMD_CONDA:        /home/ubuntu/miniconda/bin/conda
+    CMD_TEST_PYTEST:  /home/ubuntu/miniconda/envs/test/bin/pytest
+    CMD_TEST_PYTHON:  /home/ubuntu/miniconda/envs/test/bin/python
+    PATH:             /home/ubuntu/miniconda/bin:$PATH
+
+dependencies:
+  override:
+    # First convert PY_VERSIONS to an array and then select the python version based on the CIRCLE_NODE_INDEX
+    - export PY_VERSIONS=($PY_VERSIONS) &&
+      export TRAVIS_PYTHON_VERSION=${PY_VERSIONS[$CIRCLE_NODE_INDEX]} && 
+      echo -e "PYTHON = $TRAVIS_PYTHON_VERSION \n============" &&
+      git clone git://github.com/astropy/ci-helpers.git &&
+      source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh;
+    # Install dependencies. This include test and lint dependencies
+    - $CMD_CONDA install -n test --file requirements.txt -c spyder-ide -q;
+    - if [[ "${TRAVIS_PYTHON_VERSION}" == "2.7" ]] ; then $CMD_CONDA install -n test enum34 -c -q; fi
+    # Install this package
+    - $CMD_TEST_PYTHON setup.py develop;
+    # Conda information
+    - $CMD_CONDA info --json;
+
+test:
+  override:
+    # Check style
+    - export PATH="$HOME/miniconda/bin:$PATH" && source activate test && ciocheck pyswmm -dt: # note the colon
+        parallel: true
+    # Run tests (enable when pytest is implemented)
+    #- $CMD_TEST_PYTEST pyswmm --cov=pyswmm: # note the colon
+    #    parallel: true

--- a/pyswmm/__init__.py
+++ b/pyswmm/__init__.py
@@ -7,7 +7,6 @@
 # -----------------------------------------------------------------------------
 """Python Wrapper for Stormwater Management Model (SWMM5)."""
 
-
 __author__ = 'Bryant E. McDonnell (EmNet LLC) - bemcdonnell@gmail.com'
 __copyright__ = 'Copyright (c) 2016 Bryant E. McDonnell'
 __licence__ = 'BSD2'

--- a/pyswmm/links.py
+++ b/pyswmm/links.py
@@ -8,8 +8,8 @@
 """Links module for the pythonic interface to SWMM5."""
 
 # Local imports
-from swmm5 import PYSWMMException
-from toolkitapi import LinkParams, LinkResults, LinkType, ObjectType
+from pyswmm.swmm5 import PYSWMMException
+from pyswmm.toolkitapi import LinkParams, LinkResults, LinkType, ObjectType
 
 
 class Links(object):
@@ -59,6 +59,7 @@ class Links(object):
     >>> c1c2.qlimit
     >>> 12
     """
+
     def __init__(self, model):
         if not model._model.fileLoaded:
             raise PYSWMMException("SWMM Model Not Open")
@@ -125,6 +126,7 @@ class Link(object):
     ...         print c1c2.flow
     ... 0.0
     """
+
     def __init__(self, model, linkid):
         if not model.fileLoaded:
             raise PYSWMMException("SWMM Model Not Open")

--- a/pyswmm/links.py
+++ b/pyswmm/links.py
@@ -476,12 +476,14 @@ class Link(object):
         >>> 0
         >>> 0.2
         """
-        return self._model.getLinkParam(self._linkid, LinkParams.cLossInlet.value)
+        return self._model.getLinkParam(self._linkid,
+                                        LinkParams.cLossInlet.value)
 
     @inlet_head_loss.setter
     def inlet_head_loss(self, param):
         """Set Link Inlet Head Loss."""
-        self._model.setLinkParam(self._linkid, LinkParams.cLossInlet.value, param)
+        self._model.setLinkParam(self._linkid, LinkParams.cLossInlet.value,
+                                 param)
 
     @property
     def outlet_head_loss(self):
@@ -512,12 +514,14 @@ class Link(object):
         >>> 0
         >>> 0.2
         """
-        return self._model.getLinkParam(self._linkid, LinkParams.cLossOutlet.value)
+        return self._model.getLinkParam(self._linkid,
+                                        LinkParams.cLossOutlet.value)
 
     @outlet_head_loss.setter
     def outlet_head_loss(self, param):
         """Set Link Outlet Head Loss."""
-        self._model.setLinkParam(self._linkid, LinkParams.cLossOutlet.value, param)
+        self._model.setLinkParam(self._linkid, LinkParams.cLossOutlet.value,
+                                 param)
 
     @property
     def average_head_loss(self):
@@ -548,12 +552,14 @@ class Link(object):
         >>> 0
         >>> 0.2
         """
-        return self._model.getLinkParam(self._linkid, LinkParams.cLossAvg.value)
+        return self._model.getLinkParam(self._linkid,
+                                        LinkParams.cLossAvg.value)
 
     @average_head_loss.setter
     def average_head_loss(self, param):
         """Set Link Average Head Loss."""
-        self._model.setLinkParam(self._linkid, LinkParams.cLossAvg.value, param)
+        self._model.setLinkParam(self._linkid, LinkParams.cLossAvg.value,
+                                 param)
 
     @property
     def seepagerate(self):
@@ -584,12 +590,14 @@ class Link(object):
         >>> 0
         >>> 0.2
         """
-        return self._model.getLinkParam(self._linkid, LinkParams.seepRate.value)
+        return self._model.getLinkParam(self._linkid,
+                                        LinkParams.seepRate.value)
 
     @seepagerate.setter
     def seepagerate(self, param):
         """Set Link Average Seepage Loss."""
-        self._model.setLinkParam(self._linkid, LinkParams.seepRate.value, param)
+        self._model.setLinkParam(self._linkid, LinkParams.seepRate.value,
+                                 param)
 
     @property
     def flow(self):
@@ -616,7 +624,8 @@ class Link(object):
         >>> 1.9
         >>> 1.2
         """
-        return self._model.getLinkResult(self._linkid, LinkResults.newFlow.value)
+        return self._model.getLinkResult(self._linkid,
+                                         LinkResults.newFlow.value)
 
     @property
     def depth(self):
@@ -643,7 +652,8 @@ class Link(object):
         >>> 1.9
         >>> 1.2
         """
-        return self._model.getLinkResult(self._linkid, LinkResults.newDepth.value)
+        return self._model.getLinkResult(self._linkid,
+                                         LinkResults.newDepth.value)
 
     @property
     def volume(self):
@@ -670,7 +680,8 @@ class Link(object):
         >>> 1.9
         >>> 1.2
         """
-        return self._model.getLinkResult(self._linkid, LinkResults.newVolume.value)
+        return self._model.getLinkResult(self._linkid,
+                                         LinkResults.newVolume.value)
 
     @property
     def froude(self):
@@ -697,7 +708,8 @@ class Link(object):
         >>> 1.9
         >>> 1.2
         """
-        return self._model.getLinkResult(self._linkid, LinkResults.froude.value)
+        return self._model.getLinkResult(self._linkid,
+                                         LinkResults.froude.value)
 
     @property
     def ups_xsection_area(self):
@@ -724,7 +736,8 @@ class Link(object):
         >>> 1.9
         >>> 1.2
         """
-        return self._model.getLinkResult(self._linkid, LinkResults.surfArea1.value)
+        return self._model.getLinkResult(self._linkid,
+                                         LinkResults.surfArea1.value)
 
     @property
     def ds_xsection_area(self):
@@ -751,7 +764,8 @@ class Link(object):
         >>> 1.9
         >>> 1.2
         """
-        return self._model.getLinkResult(self._linkid, LinkResults.surfArea2.value)
+        return self._model.getLinkResult(self._linkid,
+                                         LinkResults.surfArea2.value)
 
     @property
     def current_setting(self):
@@ -778,7 +792,8 @@ class Link(object):
         >>> 0.5
         >>> 1
         """
-        return self._model.getLinkResult(self._linkid, LinkResults.setting.value)
+        return self._model.getLinkResult(self._linkid,
+                                         LinkResults.setting.value)
 
     @property
     def target_setting(self):

--- a/pyswmm/nodes.py
+++ b/pyswmm/nodes.py
@@ -262,12 +262,14 @@ class Node(object):
         >>> 0.1
         >>> 0.2
         """
-        return self._model.getNodeParam(self._nodeid, NodeParams.invertElev.value)
+        return self._model.getNodeParam(self._nodeid,
+                                        NodeParams.invertElev.value)
 
     @invert_elevation.setter
     def invert_elevation(self, param):
         """Set Node Invert Elevation."""
-        self._model.setNodeParam(self._nodeid, NodeParams.invertElev.value, param)
+        self._model.setNodeParam(self._nodeid, NodeParams.invertElev.value,
+                                 param)
 
     @property
     def full_depth(self):
@@ -298,12 +300,14 @@ class Node(object):
         >>> 10
         >>> 50
         """
-        return self._model.getNodeParam(self._nodeid, NodeParams.fullDepth.value)
+        return self._model.getNodeParam(self._nodeid,
+                                        NodeParams.fullDepth.value)
 
     @full_depth.setter
     def full_depth(self, param):
         """Set Node Full Depth."""
-        self._model.setNodeParam(self._nodeid, NodeParams.fullDepth.value, param)
+        self._model.setNodeParam(self._nodeid, NodeParams.fullDepth.value,
+                                 param)
 
     @property
     def surcharge_depth(self):
@@ -334,12 +338,14 @@ class Node(object):
         >>> 10
         >>> 50
         """
-        return self._model.getNodeParam(self._nodeid, NodeParams.surDepth.value)
+        return self._model.getNodeParam(self._nodeid,
+                                        NodeParams.surDepth.value)
 
     @surcharge_depth.setter
     def surcharge_depth(self, param):
         """Set Node Surcharge Depth."""
-        self._model.setNodeParam(self._nodeid, NodeParams.surDepth.value, param)
+        self._model.setNodeParam(self._nodeid, NodeParams.surDepth.value,
+                                 param)
 
     @property
     def ponding_area(self):
@@ -370,12 +376,14 @@ class Node(object):
         >>> 0
         >>> 50
         """
-        return self._model.getNodeParam(self._nodeid, NodeParams.pondedArea.value)
+        return self._model.getNodeParam(self._nodeid,
+                                        NodeParams.pondedArea.value)
 
     @ponding_area.setter
     def ponding_area(self, param):
         """Set Node Ponding Area."""
-        self._model.setNodeParam(self._nodeid, NodeParams.pondedArea.value, param)
+        self._model.setNodeParam(self._nodeid, NodeParams.pondedArea.value,
+                                 param)
 
     @property
     def initial_depth(self):
@@ -406,12 +414,14 @@ class Node(object):
         >>> 0
         >>> 1
         """
-        return self._model.getNodeParam(self._nodeid, NodeParams.initDepth.value)
+        return self._model.getNodeParam(self._nodeid,
+                                        NodeParams.initDepth.value)
 
     @initial_depth.setter
     def initial_depth(self, param):
         """Set Node Initial Depth."""
-        self._model.setNodeParam(self._nodeid, NodeParams.initDepth.value, param)
+        self._model.setNodeParam(self._nodeid, NodeParams.initDepth.value,
+                                 param)
 
     @property
     def total_inflow(self):
@@ -438,7 +448,8 @@ class Node(object):
         >>> 1.9
         >>> 1.2
         """
-        return self._model.getNodeResult(self._nodeid, NodeResults.totalinflow.value)
+        return self._model.getNodeResult(self._nodeid,
+                                         NodeResults.totalinflow.value)
 
     @property
     def total_outflow(self):
@@ -465,7 +476,8 @@ class Node(object):
         >>> 1.9
         >>> 1.2
         """
-        return self._model.getNodeResult(self._nodeid, NodeResults.outflow.value)
+        return self._model.getNodeResult(self._nodeid,
+                                         NodeResults.outflow.value)
 
     @property
     def losses(self):
@@ -492,7 +504,8 @@ class Node(object):
         >>> 0.01
         >>> 0.01
         """
-        return self._model.getNodeResult(self._nodeid, NodeResults.losses.value)
+        return self._model.getNodeResult(self._nodeid,
+                                         NodeResults.losses.value)
 
     @property
     def volume(self):
@@ -519,7 +532,8 @@ class Node(object):
         >>> 1.9
         >>> 1.2
         """
-        return self._model.getNodeResult(self._nodeid, NodeResults.newVolume.value)
+        return self._model.getNodeResult(self._nodeid,
+                                         NodeResults.newVolume.value)
 
     @property
     def flooding(self):
@@ -546,7 +560,8 @@ class Node(object):
         >>> 0
         >>> 0
         """
-        return self._model.getNodeResult(self._nodeid, NodeResults.overflow.value)
+        return self._model.getNodeResult(self._nodeid,
+                                         NodeResults.overflow.value)
 
     @property
     def depth(self):
@@ -573,7 +588,8 @@ class Node(object):
         >>> 0.52
         >>> 0.49
         """
-        return self._model.getNodeResult(self._nodeid, NodeResults.newDepth.value)
+        return self._model.getNodeResult(self._nodeid,
+                                         NodeResults.newDepth.value)
 
     @property
     def head(self):
@@ -600,7 +616,8 @@ class Node(object):
         >>> 10.52
         >>> 10.49
         """
-        return self._model.getNodeResult(self._nodeid, NodeResults.newHead.value)
+        return self._model.getNodeResult(self._nodeid,
+                                         NodeResults.newHead.value)
 
     @property
     def lateral_inflow(self):
@@ -627,7 +644,8 @@ class Node(object):
         >>> 0.3
         >>> 0.4
         """
-        return self._model.getNodeResult(self._nodeid, NodeResults.newLatFlow.value)
+        return self._model.getNodeResult(self._nodeid,
+                                         NodeResults.newLatFlow.value)
 
     def generated_inflow(self, inflowrate):
         """

--- a/pyswmm/nodes.py
+++ b/pyswmm/nodes.py
@@ -8,8 +8,8 @@
 """Nodes module for the pythonic interface to SWMM5."""
 
 # Local imports
-from swmm5 import PYSWMMException
-from toolkitapi import NodeParams, NodeResults, NodeType, ObjectType
+from pyswmm.swmm5 import PYSWMMException
+from pyswmm.toolkitapi import NodeParams, NodeResults, NodeType, ObjectType
 
 
 class Nodes(object):
@@ -63,6 +63,7 @@ class Nodes(object):
     >>> print(j1.invert_elevation)
     >>> 200
     """
+
     def __init__(self, model):
         if not model._model.fileLoaded:
             raise PYSWMMException("SWMM Model Not Open")
@@ -130,6 +131,7 @@ class Node(object):
     ...         print j1.depth
     ... 0.0
     """
+
     def __init__(self, model, nodeid):
         if not model.fileLoaded:
             raise PYSWMMException("SWMM Model Not Open")

--- a/pyswmm/pyswmm.py
+++ b/pyswmm/pyswmm.py
@@ -8,8 +8,8 @@
 """Base class for a SWMM Simulation."""
 
 # Local imports
-from swmm5 import PySWMM
-from toolkitapi import SimulationTime, SimulationUnits
+from pyswmm.swmm5 import PySWMM
+from pyswmm.toolkitapi import SimulationTime, SimulationUnits
 
 
 class Simulation(object):

--- a/pyswmm/pyswmm.py
+++ b/pyswmm/pyswmm.py
@@ -184,7 +184,8 @@ class Simulation(object):
         >>>
         >>> datetime.datetime(2015,5,10,15,15,1)
         """
-        return self._model.getSimulationDateTime(SimulationTime.StartDateTime.value)
+        return self._model.getSimulationDateTime(
+            SimulationTime.StartDateTime.value)
 
     @start_time.setter
     def start_time(self, dtimeval):
@@ -206,12 +207,14 @@ class Simulation(object):
         >>>
         >>> datetime.datetime(2016,5,10,15,15,1)
         """
-        return self._model.getSimulationDateTime(SimulationTime.EndDateTime.value)
+        return self._model.getSimulationDateTime(
+            SimulationTime.EndDateTime.value)
 
     @end_time.setter
     def end_time(self, dtimeval):
         """Set simulation End time"""
-        self._model.setSimulationDateTime(SimulationTime.EndDateTime.value, dtimeval)
+        self._model.setSimulationDateTime(SimulationTime.EndDateTime.value,
+                                          dtimeval)
 
     @property
     def report_start(self):
@@ -227,12 +230,14 @@ class Simulation(object):
         >>>
         >>> datetime.datetime(2015,5,10,15,15,1)
         """
-        return self._model.getSimulationDateTime(SimulationTime.ReportStart.value)
+        return self._model.getSimulationDateTime(
+            SimulationTime.ReportStart.value)
 
     @report_start.setter
     def report_start(self, dtimeval):
         """Set simulation report start time"""
-        self._model.setSimulationDateTime(SimulationTime.ReportStart.value, dtimeval)
+        self._model.setSimulationDateTime(SimulationTime.ReportStart.value,
+                                          dtimeval)
 
     @property
     def flow_units(self):

--- a/pyswmm/reader.py
+++ b/pyswmm/reader.py
@@ -13,7 +13,7 @@ import ctypes
 import os
 
 # Local imports
-import toolkitapi as tka
+import pyswmm.toolkitapi as tka
 
 
 class _Opaque(ctypes.Structure):
@@ -26,6 +26,7 @@ class SWMMBinReader(object):
 
     def __init__(self):
         """Instantiate python Wrapper Object and build Wrapper functions."""
+
         def get_pkgpath():
             import toolkitapi as tkp
             return os.path.dirname(tkp.__file__.replace('\\', '/'))
@@ -84,7 +85,7 @@ class SWMMBinReader(object):
             ctypes.c_int,
             ctypes.POINTER(ctypes.c_int),
             ctypes.POINTER(ctypes.c_int),
-            ]
+        ]
         self._newOutValueArray.restype = ctypes.POINTER(ctypes.c_float)
 
         # Series Builder
@@ -95,7 +96,7 @@ class SWMMBinReader(object):
             ctypes.c_int,
             ctypes.POINTER(ctypes.c_int),
             ctypes.POINTER(ctypes.c_int),
-            ]
+        ]
         self._newOutValueSeries.restype = ctypes.POINTER(ctypes.c_float)
 
         # SWMM Date num 2 String
@@ -155,15 +156,16 @@ class SWMMBinReader(object):
     def _get_SubcatchIDs(self):
         """Generates member Element IDs dictionary for Subcatchments."""
         self.SubcatchmentIDs = {}
-        for i in range(self.get_ProjectSize(
-                tka.SMO_elementCount.subcatchCount)):
+        for i in range(
+                self.get_ProjectSize(tka.SMO_elementCount.subcatchCount)):
             NAME = ctypes.create_string_buffer(46)
             LEN = ctypes.c_int(46)
-            ErrNo1 = self._getIDs(self.smoapi,
-                                  tka.SMO_elementType.SM_subcatch,
-                                  i,
-                                  ctypes.byref(NAME),
-                                  ctypes.byref(LEN))
+            ErrNo1 = self._getIDs(
+                self.smoapi,
+                tka.SMO_elementType.SM_subcatch,
+                i,
+                ctypes.byref(NAME),
+                ctypes.byref(LEN), )
             if ErrNo1 != 0:
                 error_msg = "API ErrNo {0}:{1}".format(
                     ErrNo1.value, tka.DLLErrorKeys[ErrNo1.value])
@@ -176,11 +178,12 @@ class SWMMBinReader(object):
         for i in range(self.get_ProjectSize(tka.SMO_elementCount.nodeCount)):
             NAME = ctypes.create_string_buffer(46)
             LEN = ctypes.c_int(46)
-            ErrNo1 = self._getIDs(self.smoapi,
-                                  tka.SMO_elementType.SM_node,
-                                  i,
-                                  ctypes.byref(NAME),
-                                  ctypes.byref(LEN))
+            ErrNo1 = self._getIDs(
+                self.smoapi,
+                tka.SMO_elementType.SM_node,
+                i,
+                ctypes.byref(NAME),
+                ctypes.byref(LEN), )
             if ErrNo1 != 0:
                 error_msg = "API ErrNo {0}:{1}".format(
                     ErrNo1.value, tka.DLLErrorKeys[ErrNo1.value])
@@ -193,11 +196,12 @@ class SWMMBinReader(object):
         for i in range(self.get_ProjectSize(tka.SMO_elementCount.linkCount)):
             NAME = ctypes.create_string_buffer(46)
             LEN = ctypes.c_int(46)
-            ErrNo1 = self._getIDs(self.smoapi,
-                                  tka.SMO_elementType.SM_link,
-                                  i,
-                                  ctypes.byref(NAME),
-                                  ctypes.byref(LEN))
+            ErrNo1 = self._getIDs(
+                self.smoapi,
+                tka.SMO_elementType.SM_link,
+                i,
+                ctypes.byref(NAME),
+                ctypes.byref(LEN), )
             if ErrNo1 != 0:
                 error_msg = "API ErrNo {0}:{1}".format(
                     ErrNo1.value, tka.DLLErrorKeys[ErrNo1.value])
@@ -207,15 +211,16 @@ class SWMMBinReader(object):
     def _get_PollutantIDs(self):
         """Generates member Element IDs dictionary for Pollutants."""
         self.PollutantIDs = {}
-        for i in range(self.get_ProjectSize(
-                tka.SMO_elementCount.pollutantCount)):
+        for i in range(
+                self.get_ProjectSize(tka.SMO_elementCount.pollutantCount)):
             NAME = ctypes.create_string_buffer(46)
             LEN = ctypes.c_int(46)
-            ErrNo1 = self._getIDs(self.smoapi,
-                                  tka.SMO_elementType.SM_sys,
-                                  i,
-                                  ctypes.byref(NAME),
-                                  ctypes.byref(LEN))
+            ErrNo1 = self._getIDs(
+                self.smoapi,
+                tka.SMO_elementType.SM_sys,
+                i,
+                ctypes.byref(NAME),
+                ctypes.byref(LEN), )
             if ErrNo1 != 0:
                 error_msg = "API ErrNo {0}:{1}".format(
                     ErrNo1.value, tka.DLLErrorKeys[ErrNo1.value])
@@ -290,18 +295,16 @@ class SWMMBinReader(object):
             'CMS',  # cubic meters per second
             'LPS',  # liters per second
             'MLD',  # million liters per day
-            ]
+        ]
 
         ConcUnitsType = [
             'mg',  # Milligrams / L
             'ug',  # Micrograms / L
             'COUNT',  # Counts / L
-            ]
+        ]
 
         x = ctypes.c_int()
-        ErrNo1 = self._getUnits(self.smoapi,
-                                unit,
-                                ctypes.byref(x))
+        ErrNo1 = self._getUnits(self.smoapi, unit, ctypes.byref(x))
         if ErrNo1 != 0:
             error_msg = "API ErrNo {0}:{1}".format(ErrNo1,
                                                    tka.DLLErrorKeys[ErrNo1])
@@ -331,8 +334,7 @@ class SWMMBinReader(object):
         >>> 300
         """
         timeElement = ctypes.c_int()
-        ErrNo1 = self._getTimes(self.smoapi,
-                                SMO_timeElementType,
+        ErrNo1 = self._getTimes(self.smoapi, SMO_timeElementType,
                                 ctypes.byref(timeElement))
         if ErrNo1 != 0:
             error_msg = "API ErrNo {0}:{1}".format(ErrNo1,
@@ -398,9 +400,11 @@ class SWMMBinReader(object):
              datetime.datetime(2015, 11, 29, 14, 1), ...,
              datetime.datetime(2015, 11, 29, 14, 9)]
         """
-        return [self.get_StartTime() +
-                timedelta(seconds=ind*self.get_Times(tka.SMO_time.reportStep))
-                for ind in range(self.get_Times(tka.SMO_time.numPeriods))]
+        return [
+            self.get_StartTime() + timedelta(
+                seconds=ind * self.get_Times(tka.SMO_time.reportStep))
+            for ind in range(self.get_Times(tka.SMO_time.numPeriods))
+        ]
 
     def get_ProjectSize(self, SMO_elementCount):
         """
@@ -419,8 +423,7 @@ class SWMMBinReader(object):
         >>> 10
         """
         numel = ctypes.c_int()
-        ErrNo1 = self._getProjectSize(self.smoapi,
-                                      SMO_elementCount,
+        ErrNo1 = self._getProjectSize(self.smoapi, SMO_elementCount,
                                       ctypes.byref(numel))
         if ErrNo1 != 0:
             error_msg = "API ErrNo {0}:{1}".format(ErrNo1,
@@ -480,8 +483,7 @@ class SWMMBinReader(object):
 
         sLength = ctypes.c_int()
         ErrNo1 = ctypes.c_int()
-        SeriesPtr = self._newOutValueSeries(self.smoapi,
-                                            TimeStartInd,
+        SeriesPtr = self._newOutValueSeries(self.smoapi, TimeStartInd,
                                             TimeEndInd,
                                             ctypes.byref(sLength),
                                             ctypes.byref(ErrNo1))
@@ -493,35 +495,25 @@ class SWMMBinReader(object):
         if element_type == tka.SMO_elementType.SM_subcatch:
             if not hasattr(self, 'SubcatchmentIDs'):
                 self._get_SubcatchIDs()
-            ErrNo2 = self._getSubcatchSeries(self.smoapi,
-                                             self.SubcatchmentIDs[IDName],
-                                             SMO_Attribute,
-                                             TimeStartInd, sLength.value,
-                                             SeriesPtr)
+            ErrNo2 = self._getSubcatchSeries(
+                self.smoapi, self.SubcatchmentIDs[IDName], SMO_Attribute,
+                TimeStartInd, sLength.value, SeriesPtr)
         elif element_type == tka.SMO_elementType.SM_node:
             if not hasattr(self, 'NodeIDs'):
                 self._get_NodeIDs()
-            ErrNo2 = self._getNodeSeries(self.smoapi,
-                                         self.NodeIDs[IDName],
-                                         SMO_Attribute,
-                                         TimeStartInd,
-                                         sLength.value,
-                                         SeriesPtr)
+            ErrNo2 = self._getNodeSeries(self.smoapi, self.NodeIDs[IDName],
+                                         SMO_Attribute, TimeStartInd,
+                                         sLength.value, SeriesPtr)
         elif element_type == tka.SMO_elementType.SM_link:
             if not hasattr(self, 'LinkIDs'):
                 self._get_LinkIDs()
-            ErrNo2 = self._getLinkSeries(self.smoapi,
-                                         self.LinkIDs[IDName],
-                                         SMO_Attribute,
-                                         TimeStartInd,
-                                         sLength.value,
-                                         SeriesPtr)
+            ErrNo2 = self._getLinkSeries(self.smoapi, self.LinkIDs[IDName],
+                                         SMO_Attribute, TimeStartInd,
+                                         sLength.value, SeriesPtr)
         # Add Pollutants Later
         elif element_type == tka.SMO_elementType.SM_sys:
-            ErrNo2 = self._getSystemSeries(self.smoapi,
-                                           SMO_Attribute,
-                                           TimeStartInd,
-                                           sLength.value,
+            ErrNo2 = self._getSystemSeries(self.smoapi, SMO_Attribute,
+                                           TimeStartInd, sLength.value,
                                            SeriesPtr)
         else:
             error_msg = "SMO_elementType: {} Outside Valid Types".format(
@@ -562,36 +554,28 @@ class SWMMBinReader(object):
         >>> OutputFile.get_Attribute(SM_link, flow_rate_link, 50)
         >>> [9.00419807434082, 10.011459350585938, 11.020767211914062]
         """
-        if TimeInd > self.get_Times(tka.SMO_time.numPeriods)-1:
+        if TimeInd > self.get_Times(tka.SMO_time.numPeriods) - 1:
             raise Exception("Outside Number of TimeSteps")
 
         aLength = ctypes.c_int()
         ErrNo1 = ctypes.c_int()
-        ValArrayPtr = self._newOutValueArray(self.smoapi,
-                                             tka.SMO_apiFunction.getAttribute,
-                                             element_type,
-                                             ctypes.byref(aLength),
-                                             ctypes.byref(ErrNo1))
+        ValArrayPtr = self._newOutValueArray(
+            self.smoapi, tka.SMO_apiFunction.getAttribute, element_type,
+            ctypes.byref(aLength), ctypes.byref(ErrNo1))
         if ErrNo1.value != 0:
             error_msg = "API ErrNo {0}:{1}".format(
                 ErrNo1.value, tka.DLLErrorKeys[ErrNo1.value])
             raise Exception(error_msg)
 
         if element_type == tka.SMO_elementType.SM_subcatch:
-            ErrNo2 = self._getSubcatchAttribute(self.smoapi,
-                                                TimeInd,
-                                                SMO_Attribute,
-                                                ValArrayPtr)
+            ErrNo2 = self._getSubcatchAttribute(self.smoapi, TimeInd,
+                                                SMO_Attribute, ValArrayPtr)
         elif element_type == tka.SMO_elementType.SM_link:
-            ErrNo2 = self._getLinkAttribute(self.smoapi,
-                                            TimeInd,
-                                            SMO_Attribute,
-                                            ValArrayPtr)
+            ErrNo2 = self._getLinkAttribute(self.smoapi, TimeInd,
+                                            SMO_Attribute, ValArrayPtr)
         elif element_type == tka.SMO_elementType.SM_node:
-            ErrNo2 = self._getNodeAttribute(self.smoapi,
-                                            TimeInd,
-                                            SMO_Attribute,
-                                            ValArrayPtr)
+            ErrNo2 = self._getNodeAttribute(self.smoapi, TimeInd,
+                                            SMO_Attribute, ValArrayPtr)
         # Add Pollutants Later
         else:
             error_msg = "SMO_elementType: {} Outside Valid Types".format(
@@ -634,47 +618,40 @@ class SWMMBinReader(object):
         >>> [70.0, 0.0, 0.0, 0.0, 0.0, 8.0, 0.0, 0.0, 3.0, 11.0, 0.0,
              11.000021934509277, 532.2583618164062, 0.0, 0.0]
         """
-        if TimeInd > self.get_Times(tka.SMO_time.numPeriods)-1:
+        if TimeInd > self.get_Times(tka.SMO_time.numPeriods) - 1:
             raise Exception("Outside Number of TimeSteps")
 
         alength = ctypes.c_int()
         ErrNo1 = ctypes.c_int()
-        ValArrayPtr = self._newOutValueArray(self.smoapi,
-                                             tka.SMO_apiFunction.getResult,
-                                             element_type,
-                                             ctypes.byref(alength),
-                                             ctypes.byref(ErrNo1))
+        ValArrayPtr = self._newOutValueArray(
+            self.smoapi, tka.SMO_apiFunction.getResult, element_type,
+            ctypes.byref(alength), ctypes.byref(ErrNo1))
 
         if element_type == tka.SMO_elementType.SM_subcatch:
             if not hasattr(self, 'SubcatchmentIDs'):
                 self._get_SubcatchIDs()
-            ErrNo2 = self._getSubcatchResult(self.smoapi,
-                                             TimeInd,
+            ErrNo2 = self._getSubcatchResult(self.smoapi, TimeInd,
                                              self.SubcatchmentIDs[IDName],
                                              ValArrayPtr)
         elif element_type == tka.SMO_elementType.SM_node:
             if not hasattr(self, 'NodeIDs'):
                 self._get_NodeIDs()
-            ErrNo2 = self._getNodeResult(self.smoapi,
-                                         TimeInd,
-                                         self.NodeIDs[IDName],
-                                         ValArrayPtr)
+            ErrNo2 = self._getNodeResult(self.smoapi, TimeInd,
+                                         self.NodeIDs[IDName], ValArrayPtr)
         elif element_type == tka.SMO_elementType.SM_link:
             if not hasattr(self, 'LinkIDs'):
                 self._get_LinkIDs()
-            ErrNo2 = self._getLinkResult(self.smoapi,
-                                         TimeInd,
-                                         self.LinkIDs[IDName],
-                                         ValArrayPtr)
+            ErrNo2 = self._getLinkResult(self.smoapi, TimeInd,
+                                         self.LinkIDs[IDName], ValArrayPtr)
         # Add Pollutants Later
         elif element_type == tka.SMO_elementType.SM_sys:
-            # This is not used?
             ErrNo2 = self._getSystemResult(self.smoapi, TimeInd, ValArrayPtr)
         else:
             error_msg = "SMO_elementType: {} Outside Valid Types".format(
                 element_type)
             raise Exception(error_msg)
 
+        ErrNo2  # FIXME: is this not used?
         BldArray = [ValArrayPtr[i] for i in range(alength.value)]
         self._free(ValArrayPtr)
         return BldArray
@@ -723,27 +700,22 @@ if __name__ in "__main__":
     # Get Series
     print("\nSeries Tests")
     SubcSeries = Test.get_Series(tka.SMO_elementType.SM_subcatch,
-                                 tka.SMO_systemAttribute.runoff_rate,
-                                 'S3',
-                                 0,
+                                 tka.SMO_systemAttribute.runoff_rate, 'S3', 0,
                                  50)
     print(SubcSeries)
     NodeSeries = Test.get_Series(tka.SMO_elementType.SM_node,
-                                 tka.SMO_systemAttribute.invert_depth,
-                                 'J1',
-                                 0,
+                                 tka.SMO_systemAttribute.invert_depth, 'J1', 0,
                                  50)
     print(NodeSeries)
     LinkSeries = Test.get_Series(tka.SMO_elementType.SM_link,
                                  tka.SMO_systemAttribute.rainfall_subcatch,
-                                 'C2',
-                                 0,
-                                 50)
+                                 'C2', 0, 50)
     print(LinkSeries)
-    SystSeries = Test.get_Series(tka.SMO_elementType.SM_sys,
-                                 tka.SMO_systemAttribute.rainfall_system,
-                                 TimeStartInd=0,
-                                 TimeEndInd=50)
+    SystSeries = Test.get_Series(
+        tka.SMO_elementType.SM_sys,
+        tka.SMO_systemAttribute.rainfall_system,
+        TimeStartInd=0,
+        TimeEndInd=50)
     print(SystSeries)
 
     # Get Attributes
@@ -751,12 +723,10 @@ if __name__ in "__main__":
     # Check Values.. Might be issue here
     SubcAttributes = Test.get_Attribute(
         tka.SMO_elementType.SM_subcatch,
-        tka.SMO_systemAttribute.rainfall_subcatch,
-        0)
+        tka.SMO_systemAttribute.rainfall_subcatch, 0)
     print(SubcAttributes)
-    NodeAttributes = Test.get_Attribute(tka.SMO_elementType.SM_node,
-                                        tka.SMO_systemAttribute.invert_depth,
-                                        10)
+    NodeAttributes = Test.get_Attribute(
+        tka.SMO_elementType.SM_node, tka.SMO_systemAttribute.invert_depth, 10)
     print(NodeAttributes)
     LinkAttributes = Test.get_Attribute(tka.SMO_elementType.SM_link,
                                         tka.SMO_systemAttribute.flow_rate_link,

--- a/pyswmm/swmm5.py
+++ b/pyswmm/swmm5.py
@@ -19,14 +19,15 @@ import sys
 import warnings
 
 # Local imports
-import toolkitapi as tka
+import pyswmm.toolkitapi as tka
 
 
 class SWMMException(Exception):
     """Custom exception class for SWMM errors."""
+
     def __init__(self, error_code, error_message):
         self.warning = False
-        self.args = (error_code,)
+        self.args = (error_code, )
         self.message = error_message
 
     def __str__(self):
@@ -35,6 +36,7 @@ class SWMMException(Exception):
 
 class PYSWMMException(Exception):
     """Custom exception class for PySWMM errors. """
+
     def __init__(self, error_message):
         self.warning = False
         self.message = error_message
@@ -121,9 +123,7 @@ class PySWMM(object):
         if 'win32' in sys.platform:
             if dllpath is None:
                 dllname = 'swmm5.dll'
-                libswmm = os.path.join(get_pkgpath() +
-                                       '\\swmmLinkedLibs\\Windows\\' +
-                                       dllname)
+                libswmm = get_pkgpath() + '\\swmmLinkedLibs\\Windows\\' + dllname)
             else:
                 libswmm = dllpath
             self.SWMMlibobj = ctypes.CDLL(libswmm)
@@ -357,7 +357,7 @@ class PySWMM(object):
             self.curSimTime = 0.000001
 
         ctime = self.curSimTime
-        while advanceSeconds/3600./24. + ctime > self.curSimTime:
+        while advanceSeconds / 3600. / 24. + ctime > self.curSimTime:
             elapsed_time = ctypes.c_double()
             self.SWMMlibobj.swmm_step(ctypes.byref(elapsed_time))
             self.curSimTime = elapsed_time.value
@@ -1153,9 +1153,10 @@ class PySWMM(object):
 
 
 if __name__ == '__main__':
-    test = PySWMM(inpfile=r"../test/TestModel1_weirSetting.inp",
-                  rptfile=r"../test/TestModel1_weirSetting.rpt",
-                  binfile=r"../test/TestModel1_weirSetting.out")
+    test = PySWMM(
+        inpfile=r"../test/TestModel1_weirSetting.inp",
+        rptfile=r"../test/TestModel1_weirSetting.rpt",
+        binfile=r"../test/TestModel1_weirSetting.out")
     test.swmm_open()
 
     print("Simulation Time Info")

--- a/pyswmm/swmm5.py
+++ b/pyswmm/swmm5.py
@@ -123,7 +123,8 @@ class PySWMM(object):
         if 'win32' in sys.platform:
             if dllpath is None:
                 dllname = 'swmm5.dll'
-                libswmm = get_pkgpath() + '\\swmmLinkedLibs\\Windows\\' + dllname)
+                libswmm = (
+                    get_pkgpath() + '\\swmmLinkedLibs\\Windows\\' + dllname)
             else:
                 libswmm = dllpath
             self.SWMMlibobj = ctypes.CDLL(libswmm)
@@ -184,8 +185,8 @@ class PySWMM(object):
             else:
                 binfile = self.inpfile.replace('.inp', '.out')
 
-        sys.stdout.write("\n... SWMM Version {}".format(
-            self.swmm_getVersion()))
+        sys.stdout.write("\n... SWMM Version {}".format(self.swmm_getVersion(
+        )))
 
         try:
             self.swmm_run()
@@ -218,9 +219,9 @@ class PySWMM(object):
             else:
                 binfile = self.inpfile.replace('.inp', '.out')
 
-        self.SWMMlibobj.swmm_run(ctypes.c_char_p(inpfile),
-                                 ctypes.c_char_p(rptfile),
-                                 ctypes.c_char_p(binfile))
+        self.SWMMlibobj.swmm_run(
+            ctypes.c_char_p(inpfile),
+            ctypes.c_char_p(rptfile), ctypes.c_char_p(binfile))
 
     def swmm_open(self, inpfile=None, rptfile=None, binfile=None):
         """
@@ -239,7 +240,7 @@ class PySWMM(object):
         if self.fileLoaded:
             self.swmm_close()
             error_msg = 'Fatal error closing previously opened file'
-            raise(PYSWMMException(error_msg))
+            raise (PYSWMMException(error_msg))
 
         if inpfile is None:
             inpfile = self.inpfile
@@ -256,9 +257,9 @@ class PySWMM(object):
             else:
                 binfile = self.inpfile.replace('.inp', '.out')
 
-        errcode = self.SWMMlibobj.swmm_open(ctypes.c_char_p(inpfile),
-                                            ctypes.c_char_p(rptfile),
-                                            ctypes.c_char_p(binfile))
+        errcode = self.SWMMlibobj.swmm_open(
+            ctypes.c_char_p(inpfile),
+            ctypes.c_char_p(rptfile), ctypes.c_char_p(binfile))
         self._error_check(errcode)
         self.fileLoaded = True
 
@@ -429,9 +430,9 @@ class PySWMM(object):
         flowErr = ctypes.c_float()
         qualErr = ctypes.c_float()
 
-        errcode = self.SWMMlibobj.swmm_getMassBalErr(ctypes.byref(runoffErr),
-                                                     ctypes.byref(flowErr),
-                                                     ctypes.byref(qualErr))
+        errcode = self.SWMMlibobj.swmm_getMassBalErr(
+            ctypes.byref(runoffErr),
+            ctypes.byref(flowErr), ctypes.byref(qualErr))
         self._error_check(errcode)
         return runoffErr.value, flowErr.value, qualErr.value
 
@@ -552,8 +553,8 @@ class PySWMM(object):
         >>> swmm_model.swmm_close()
         """
         value = ctypes.c_double()
-        errcode = self.SWMMlibobj.swmm_getSimulationParam(
-            paramtype, ctypes.byref(value))
+        errcode = self.SWMMlibobj.swmm_getSimulationParam(paramtype,
+                                                          ctypes.byref(value))
         self._error_check(errcode)
         return value.value
 
@@ -574,8 +575,8 @@ class PySWMM(object):
         >>> swmm_model.swmm_close()
         """
         count = ctypes.c_int()
-        errcode = self.SWMMlibobj.swmm_countObjects(
-            objecttype, ctypes.byref(count))
+        errcode = self.SWMMlibobj.swmm_countObjects(objecttype,
+                                                    ctypes.byref(count))
         self._error_check(errcode)
         return count.value
 
@@ -598,8 +599,8 @@ class PySWMM(object):
         >>> swmm_model.swmm_close()
         """
         ID = ctypes.create_string_buffer(61)
-        errcode = self.SWMMlibobj.swmm_getObjectId(
-            objecttype, index, ctypes.byref(ID))
+        errcode = self.SWMMlibobj.swmm_getObjectId(objecttype, index,
+                                                   ctypes.byref(ID))
         self._error_check(errcode)
         return ID.value
 
@@ -775,8 +776,7 @@ class PySWMM(object):
         """
         index = self.getObjectIDIndex(tka.ObjectType.NODE.value, ID)
         param = ctypes.c_double()
-        errcode = self.SWMMlibobj.swmm_getNodeParam(index,
-                                                    Parameter,
+        errcode = self.SWMMlibobj.swmm_getNodeParam(index, Parameter,
                                                     ctypes.byref(param))
         self._error_check(errcode)
         return param.value
@@ -798,9 +798,7 @@ class PySWMM(object):
         """
         index = self.getObjectIDIndex(tka.ObjectType.NODE.value, ID)
         _val = ctypes.c_double(value)
-        errcode = self.SWMMlibobj.swmm_setNodeParam(index,
-                                                    Parameter,
-                                                    _val)
+        errcode = self.SWMMlibobj.swmm_setNodeParam(index, Parameter, _val)
         self._error_check(errcode)
 
     def getLinkParam(self, ID, Parameter):
@@ -823,8 +821,7 @@ class PySWMM(object):
         """
         index = self.getObjectIDIndex(tka.ObjectType.LINK.value, ID)
         param = ctypes.c_double()
-        errcode = self.SWMMlibobj.swmm_getLinkParam(index,
-                                                    Parameter,
+        errcode = self.SWMMlibobj.swmm_getLinkParam(index, Parameter,
                                                     ctypes.byref(param))
         self._error_check(errcode)
         return param.value
@@ -846,9 +843,7 @@ class PySWMM(object):
         """
         index = self.getObjectIDIndex(tka.ObjectType.LINK.value, ID)
         _val = ctypes.c_double(value)
-        errcode = self.SWMMlibobj.swmm_setLinkParam(index,
-                                                    Parameter,
-                                                    _val)
+        errcode = self.SWMMlibobj.swmm_setLinkParam(index, Parameter, _val)
         self._error_check(errcode)
 
     def getSubcatchParam(self, ID, Parameter):
@@ -871,8 +866,7 @@ class PySWMM(object):
         """
         index = self.getObjectIDIndex(tka.ObjectType.SUBCATCH.value, ID)
         param = ctypes.c_double()
-        errcode = self.SWMMlibobj.swmm_getSubcatchParam(index,
-                                                        Parameter,
+        errcode = self.SWMMlibobj.swmm_getSubcatchParam(index, Parameter,
                                                         ctypes.byref(param))
         self._error_check(errcode)
         return param.value
@@ -929,18 +923,18 @@ class PySWMM(object):
         TYPELoadSurface = ctypes.c_int()
         outindex = ctypes.c_int()
         errcode = self.SWMMlibobj.swmm_getSubcatchOutConnection(
-            index,
-            ctypes.byref(TYPELoadSurface),
-            ctypes.byref(outindex))
+            index, ctypes.byref(TYPELoadSurface), ctypes.byref(outindex))
         self._error_check(errcode)
 
         if TYPELoadSurface.value == tka.ObjectType.NODE.value:
-            LoadID = self.getObjectId(tka.ObjectType.NODE.value, outindex.value)
+            LoadID = self.getObjectId(tka.ObjectType.NODE.value,
+                                      outindex.value)
 
         if TYPELoadSurface.value == tka.ObjectType.SUBCATCH.value:
-            LoadID = self.getObjectId(tka.ObjectType.SUBCATCH.value, outindex.value)
+            LoadID = self.getObjectId(tka.ObjectType.SUBCATCH.value,
+                                      outindex.value)
 
-        return(TYPELoadSurface.value, LoadID)
+        return (TYPELoadSurface.value, LoadID)
 
     # --- Active Simulation Result "Getters"
     # -------------------------------------------------------------------------
@@ -1005,8 +999,7 @@ class PySWMM(object):
         """
         index = self.getObjectIDIndex(tka.ObjectType.NODE.value, ID)
         result = ctypes.c_double()
-        errcode = self.SWMMlibobj.swmm_getNodeResult(index,
-                                                     resultType,
+        errcode = self.SWMMlibobj.swmm_getNodeResult(index, resultType,
                                                      ctypes.byref(result))
         self._error_check(errcode)
         return result.value
@@ -1041,8 +1034,7 @@ class PySWMM(object):
         """
         index = self.getObjectIDIndex(tka.ObjectType.LINK.value, ID)
         result = ctypes.c_double()
-        errcode = self.SWMMlibobj.swmm_getLinkResult(index,
-                                                     resultType,
+        errcode = self.SWMMlibobj.swmm_getLinkResult(index, resultType,
                                                      ctypes.byref(result))
         self._error_check(errcode)
         return result.value
@@ -1077,8 +1069,7 @@ class PySWMM(object):
         """
         index = self.getObjectIDIndex(tka.ObjectType.SUBCATCH.value, ID)
         result = ctypes.c_double()
-        errcode = self.SWMMlibobj.swmm_getSubcatchResult(index,
-                                                         resultType,
+        errcode = self.SWMMlibobj.swmm_getSubcatchResult(index, resultType,
                                                          ctypes.byref(result))
         self._error_check(errcode)
 
@@ -1171,7 +1162,9 @@ if __name__ == '__main__':
     print(test.getSimUnit(tka.SimulationUnits.FlowUnits.value))
 
     print("Simulation Allow Ponding Option Selection")
-    print(test.getSimAnalysisSetting(tka.SimAnalysisSettings.AllowPonding.value))
+    print(
+        test.getSimAnalysisSetting(tka.SimAnalysisSettings.AllowPonding.value),
+    )
 
     print("Simulation Routing Step")
     print(test.getSimAnalysisSetting(tka.SimulationParameters.RouteStep.value))
@@ -1184,23 +1177,32 @@ if __name__ == '__main__':
     print(IDS)
     print('ID,Invert,Type')
     for ind, idd in enumerate(IDS):
-        print(ind, idd, test.getNodeParam(idd, tka.NodeParams.invertElev.value),
-              test.getNodeParam(idd, tka.NodeParams.fullDepth.value),
-              test.getNodeType(idd))
+        print(
+            ind,
+            idd,
+            test.getNodeParam(idd, tka.NodeParams.invertElev.value),
+            test.getNodeParam(idd, tka.NodeParams.fullDepth.value),
+            test.getNodeType(idd), )
 
     print("Link ID")
     print('ID,offset1,LinkConnections')
     IDS = test.getObjectIDList(tka.ObjectType.LINK.value)
     print(IDS)
     for ind, idd in enumerate(IDS):
-        print(ind, idd, test.getLinkParam(idd, tka.LinkParams.offset1.value),
-              test.getLinkConnections(idd))
+        print(
+            ind,
+            idd,
+            test.getLinkParam(idd, tka.LinkParams.offset1.value),
+            test.getLinkConnections(idd), )
 
     print("SUBCATCH ID")
     IDS = test.getObjectIDList(tka.ObjectType.SUBCATCH.value)
     print(IDS)
     for ind, idd in enumerate(IDS):
-        print(ind, idd, test.getSubcatchParam(idd, tka.SubcParams.area.value),
-              test.getSubcatchOutConnection(idd))
+        print(
+            ind,
+            idd,
+            test.getSubcatchParam(idd, tka.SubcParams.area.value),
+            test.getSubcatchOutConnection(idd), )
 
     test.swmm_close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# Build dependencies
+#python
+#setuptools
+
+# Run dependencies
+
+# Test/Dev dependencies
+ciocheck
+coveralls

--- a/setup.py
+++ b/setup.py
@@ -11,43 +11,35 @@
 import sys
 
 # Third party imports
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 PY2 = sys.version_info.major == 2
 VERSION = '0.2.1'
-AUTHOR_NAME = 'Bryant E. McDonnell (EmNet LLC)'
-AUTHOR_EMAIL = 'bemcdonnell@gmail.com'
-
 
 REQUIREMENTS = []
-
 
 if PY2:
     REQUIREMENTS.append('enum34')
 
-
-setup(name='pyswmm',
-      version=VERSION,
-      description='Python Wrapper for SWMM5 API',
-      url='https://github.com/OpenWaterAnalytics/pyswmm/wiki',
-      author=AUTHOR_NAME,
-      author_email=AUTHOR_EMAIL,
-      install_requires=REQUIREMENTS,
-      package_dir={'': 'pyswmm'},
-      packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-      package_data={'':
-                    ['swmmLinkedLibs/Windows/swmm5.dll',
-                     'LICENSE.txt']},
-      include_package_data=True,
-      license="BSD2 License",
-      keywords = "swmm5, swmm, hydraulics, hydrology, modeling, collection system",
-      classifiers=[
-          "Topic :: Scientific/Engineering",
-          "Topic :: Documentation :: Sphinx",
-          "Operating System :: Microsoft :: Windows",
-          "License :: OSI Approved :: BSD License",
-          "Programming Language :: Python :: 2.7",
-          "Programming Language :: C",
-          "Development Status :: 4 - Beta",
-          ]
-      )
+setup(
+    name='pyswmm',
+    version=VERSION,
+    description='Python Wrapper for SWMM5 API',
+    url='https://github.com/OpenWaterAnalytics/pyswmm/wiki',
+    author='Bryant E. McDonnell (EmNet LLC)',
+    author_email='bemcdonnell@gmail.com',
+    install_requires=REQUIREMENTS,
+    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+    package_data={'': ['swmmLinkedLibs/Windows/swmm5.dll', 'LICENSE.txt']},
+    include_package_data=True,
+    license="BSD2 License",
+    keywords="swmm5, swmm, hydraulics, hydrology, modeling, collection system",
+    classifiers=[
+        "Topic :: Scientific/Engineering",
+        "Topic :: Documentation :: Sphinx",
+        "Operating System :: Microsoft :: Windows",
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: C",
+        "Development Status :: 4 - Beta",
+    ])


### PR DESCRIPTION
Fixes #44 
Fixes #15 
Fixes #12 
 
@bemcdonnell this seems like a rather large PR, but most of the changes belong to the automatic code formatter (yapf and isort). Current style checks run for 2.7, 3.5 and 3.6 (although this is meant for running the actual tests, next PR)

I am using a library I helped write and we are using it on other projects (ciocheck)

Basically the CI tests will check if the code changes based on the autoformatter, if it does, then the test fails as it means you did not autoformat the code before pushing the commit. It will also check style for docstrings, pep8, flake8 and others!

This is also enforcing a 79 column limit, which we can change to 99 which is a more modern value.

So basically before making a commit you always need to run ciocheck

If using conda you can install it with

```
conda install ciocheck -c spyder-ide
ciocheck pyswmm -dt
```

This will run the checks but no tests. Tests will be updated in the next PR.
