### PR TITLE
Supply the missed lib/linux/swmm5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     package_data={
         '': [
-            'lib/windows/swmm5.dll', 'lib/macos/swmm5.so', 'LICENSE.txt',
-            'AUTHORS', 'tests/data/*.inp', 'tests/*.py'
+            'lib/windows/swmm5.dll', 'lib/macos/swmm5.so', 'lib/linux/swmm5.so',
+            'LICENSE.txt', 'AUTHORS', 'tests/data/*.inp', 'tests/*.py'
         ]
     },
     include_package_data=True,


### PR DESCRIPTION
If setup.py file misses this information item, it can't copy the swmm5.so file into python lib folder so that it will make some bad behaviors such as "Library Not Found" in Linux platform.