### PR TITLE
Update system.py docs

### DIFF
--- a/pyswmm/system.py
+++ b/pyswmm/system.py
@@ -19,12 +19,12 @@ class SystemStats(object):
 
     Examples:
 
-    >>> from pyswmm import Simulation, SystemFlowRouting
+    >>> from pyswmm import Simulation, SystemStats
     >>>
     >>> with Simulation('tests/data/TestModel1_weirSetting.inp') as sim:
     ...     system_routing = SystemStats(sim)
     ...
-    ...     for step in simulation:
+    ...     for step in sim:
     ...         print system_routing.routing_stats
     ...         print system_routing.runoff_stats
     """


### PR DESCRIPTION
Closes #163 

Two updates in System.py module:

In line 22, pyswmm package doesn't include the SystemFlowRouting. In this way, the syntax of "from pyswmm import Simulation, SystemFlowRouting" was updated to be "from pyswmm import Simulation, SystemStats" if we want to extract system statistics.

In line 27,‘’Simulation' has been demonstrated as ‘’sim”. Thus, the syntax of "for step in simulation" was changed to be "for step in sim".

Jiada