### PR TITLE
change single ptr struct to double ptr struct for ctypes for subcatch

### DIFF
--- a/pyswmm/swmm5.py
+++ b/pyswmm/swmm5.py
@@ -1796,23 +1796,23 @@ class PySWMM(object):
         # SWMM function handle.
         swmm_stats_func = self.SWMMlibobj.swmm_getSubcatchStats
         # SWMM function handle argument output structure.
-        swmm_stats_func_arg = ctypes.POINTER(tka.SubcStats)
+        swmm_stats_func_arg = ctypes.POINTER(ctypes.POINTER(tka.SubcStats))
         # Define argument.
         swmm_stats_func.argtypes = (
             ctypes.c_int,
             swmm_stats_func_arg, )
 
-        object_stats = tka.SubcStats()
+        object_ptr = ctypes.POINTER(tka.SubcStats)()
         errcode = swmm_stats_func(
-            ctypes.c_int(index), ctypes.byref(object_stats))
+            ctypes.c_int(index), ctypes.byref(object_ptr))
 
         self._error_check(errcode)
         # Copy Items to Dictionary using Alias Names.
         out_dict = {}
-        for attr in dir(object_stats):
+        for attr in dir(object_ptr.contents):
             if "_" not in attr:
-                out_dict[object_stats._py_alias_ids[attr]] = getattr(
-                    object_stats, attr)
+                out_dict[object_ptr.contents._py_alias_ids[attr]] = getattr(
+                    object_ptr.contents, attr)
 
         return out_dict
 

--- a/pyswmm/tests/data/__init__.py
+++ b/pyswmm/tests/data/__init__.py
@@ -24,6 +24,7 @@ MODEL_POLLUTANTS_PATH = os.path.join(DATA_PATH, 'model_pollutants.inp')
 MODEL_RAIN = os.path.join(DATA_PATH, 'model_rain.inp')
 MODEL_LIDS_PATH = os.path.join(DATA_PATH, 'model_lids.inp')
 MODEL_BAD_INPUT_PATH_1 = os.path.join(DATA_PATH, 'model_bad_input_1.inp')
+MODEL_SUBCATCH_STATS_PATH = os.path.join(DATA_PATH, 'model_subcatch_stats.inp')
 
 WIN_SWMM_LIB_PATH = os.path.join(DATA_PATH, '..\\..\\lib\\windows',
                                  'swmm5.dll')

--- a/pyswmm/tests/data/model_subcatch_stats.inp
+++ b/pyswmm/tests/data/model_subcatch_stats.inp
@@ -1,0 +1,218 @@
+[TITLE]
+;;Project Title/Notes
+
+[OPTIONS]
+;;Option            	Value
+FLOW_UNITS          	CFS
+INFILTRATION        	HORTON
+FLOW_ROUTING        	KINWAVE
+LINK_OFFSETS        	DEPTH
+MIN_SLOPE           	0
+ALLOW_PONDING       	NO
+SKIP_STEADY_STATE   	NO
+
+START_DATE          	10/02/2019
+START_TIME          	00:00:00
+REPORT_START_DATE   	10/02/2019
+REPORT_START_TIME   	00:00:00
+END_DATE            	10/02/2019
+END_TIME            	06:00:00
+SWEEP_START         	1/1
+SWEEP_END           	12/31
+DRY_DAYS            	0
+REPORT_STEP         	00:15:00
+WET_STEP            	00:05:00
+DRY_STEP            	01:00:00
+ROUTING_STEP        	0:00:30 
+RULE_STEP           	00:00:00
+
+INERTIAL_DAMPING    	PARTIAL
+NORMAL_FLOW_LIMITED 	BOTH
+FORCE_MAIN_EQUATION 	H-W
+VARIABLE_STEP       	0.75
+LENGTHENING_STEP    	0
+MIN_SURFAREA        	0
+MAX_TRIALS          	0
+HEAD_TOLERANCE      	0
+SYS_FLOW_TOL        	5
+LAT_FLOW_TOL        	5
+MINIMUM_STEP        	0.5
+THREADS             	1
+
+[EVAPORATION]
+;;Data Source   	Parameters
+;;--------------	----------------
+CONSTANT        	0.0
+DRY_ONLY        	NO
+
+[RAINGAGES]
+;;Name          	Format   	Interval	SCF     	Source    
+;;--------------	---------	------	------	----------
+1               	INTENSITY	0:15    	1.0     	TIMESERIES	TS1             
+
+[SUBCATCHMENTS]
+;;Name          	Rain Gage       	Outlet          	Area    	%Imperv 	Width   	%Slope  	CurbLen 	SnowPack        
+;;--------------	----------------	----------------	--------	--------	--------	--------	--------	----------------
+S1              	1               	S2              	5       	100     	500     	0.5     	0       	                
+S2              	1               	1               	5       	0       	500     	0.5     	0       	                
+
+[SUBAREAS]
+;;Subcatchment  	N-Imperv  	N-Perv    	S-Imperv  	S-Perv    	PctZero   	RouteTo   	PctRouted 
+;;--------------	----------	----------	----------	----------	----------	----------	----------
+S1              	0.01      	0.1       	0.05      	0.05      	25        	OUTLET    
+S2              	0.01      	0.1       	0.05      	0.05      	25        	OUTLET    
+
+[INFILTRATION]
+;;Subcatchment  	MaxRate   	MinRate   	Decay     	DryTime   	MaxInfil  
+;;--------------	----------	----------	----------	----------	----------
+S1              	3.0       	0.5       	4         	7         	0         
+S2              	3.0       	0.5       	4         	7         	0         
+
+[OUTFALLS]
+;;Name          	Elevation 	Type      	Stage Data      	Gated   	Route To        
+;;--------------	----------	----------	----------------	--------	----------------
+1               	0         	FREE      	                	NO      	                
+
+[TIMESERIES]
+;;Name          	Date      	Time      	Value     
+;;--------------	----------	----------	----------
+TS1             	          	0:00      	0.0175    
+TS1             	          	0:15      	0.0175    
+TS1             	          	0:30      	0.0175    
+TS1             	          	0:45      	0.0175    
+TS1             	          	1:00      	0.0175    
+TS1             	          	1:15      	0.0175    
+TS1             	          	1:30      	0.0175    
+TS1             	          	1:45      	0.0175    
+TS1             	          	2:00      	0.0205    
+TS1             	          	2:15      	0.0205    
+TS1             	          	2:30      	0.0205    
+TS1             	          	2:45      	0.0205    
+TS1             	          	3:00      	0.0205    
+TS1             	          	3:15      	0.0205    
+TS1             	          	3:30      	0.0205    
+TS1             	          	3:45      	0.0205    
+TS1             	          	4:00      	0.0245    
+TS1             	          	4:15      	0.0245    
+TS1             	          	4:30      	0.0245    
+TS1             	          	4:45      	0.0245    
+TS1             	          	5:00      	0.0245    
+TS1             	          	5:15      	0.0245    
+TS1             	          	5:30      	0.0245    
+TS1             	          	5:45      	0.0245    
+TS1             	          	6:00      	0.031     
+TS1             	          	6:15      	0.031     
+TS1             	          	6:30      	0.031     
+TS1             	          	6:45      	0.031     
+TS1             	          	7:00      	0.038     
+TS1             	          	7:15      	0.038     
+TS1             	          	7:30      	0.038     
+TS1             	          	7:45      	0.038     
+TS1             	          	8:00      	0.05      
+TS1             	          	8:15      	0.05      
+TS1             	          	8:30      	0.07      
+TS1             	          	8:45      	0.07      
+TS1             	          	9:00      	0.098     
+TS1             	          	9:15      	0.098     
+TS1             	          	9:30      	0.236     
+TS1             	          	9:45      	0.612     
+TS1             	          	10:00     	0.136     
+TS1             	          	10:15     	0.136     
+TS1             	          	10:30     	0.082     
+TS1             	          	10:45     	0.082     
+TS1             	          	11:00     	0.06      
+TS1             	          	11:15     	0.06      
+TS1             	          	11:30     	0.06      
+TS1             	          	11:45     	0.052     
+TS1             	          	12:00     	0.048     
+TS1             	          	12:15     	0.048     
+TS1             	          	12:30     	0.042     
+TS1             	          	12:45     	0.042     
+TS1             	          	13:00     	0.042     
+TS1             	          	13:15     	0.042     
+TS1             	          	13:30     	0.038     
+TS1             	          	13:45     	0.038     
+TS1             	          	14:00     	0.0315    
+TS1             	          	14:15     	0.0315    
+TS1             	          	14:30     	0.0315    
+TS1             	          	14:45     	0.0315    
+TS1             	          	15:00     	0.0315    
+TS1             	          	15:15     	0.0315    
+TS1             	          	15:30     	0.0315    
+TS1             	          	15:45     	0.0315    
+TS1             	          	16:00     	0.024     
+TS1             	          	16:15     	0.024     
+TS1             	          	16:30     	0.024     
+TS1             	          	16:45     	0.024     
+TS1             	          	17:00     	0.024     
+TS1             	          	17:15     	0.024     
+TS1             	          	17:30     	0.024     
+TS1             	          	17:45     	0.024     
+TS1             	          	18:00     	0.024     
+TS1             	          	18:15     	0.024     
+TS1             	          	18:30     	0.024     
+TS1             	          	18:45     	0.024     
+TS1             	          	19:00     	0.024     
+TS1             	          	19:15     	0.024     
+TS1             	          	19:30     	0.024     
+TS1             	          	19:45     	0.024     
+TS1             	          	20:00     	0.0185    
+TS1             	          	20:15     	0.0185    
+TS1             	          	20:30     	0.0185    
+TS1             	          	20:45     	0.0185    
+TS1             	          	21:00     	0.0185    
+TS1             	          	21:15     	0.0185    
+TS1             	          	21:30     	0.0185    
+TS1             	          	21:45     	0.0185    
+TS1             	          	22:00     	0.0185    
+TS1             	          	22:15     	0.0185    
+TS1             	          	22:30     	0.0185    
+TS1             	          	22:45     	0.0185    
+TS1             	          	23:00     	0.0185    
+TS1             	          	23:15     	0.0185    
+TS1             	          	23:30     	0.0185    
+TS1             	          	23:45     	0.0185    
+TS1             	          	24:00:00  	0         
+TS1             	          	24:15:00  	0         
+TS1             	          	24:30:00  	0         
+TS1             	          	24:45:00  	0         
+TS1             	          	25:00:00  	0         
+
+[REPORT]
+;;Reporting Options
+SUBCATCHMENTS	ALL
+NODES	ALL
+LINKS	ALL
+
+[TAGS]
+
+[MAP]
+DIMENSIONS	0.000	0.000	10000.000	10000.000
+Units     	None
+
+[COORDINATES]
+;;Node          	X-Coord           	Y-Coord           
+;;--------------	------------------	------------------
+1               	7448.454          	3762.887          
+
+[VERTICES]
+;;Link          	X-Coord           	Y-Coord           
+;;--------------	------------------	------------------
+
+[Polygons]
+;;Subcatchment  	X-Coord           	Y-Coord           
+;;--------------	------------------	------------------
+S1              	-12551.546        	2731.959          
+S1              	-6675.258         	3659.794          
+S1              	-7036.082         	7731.959          
+S1              	-12551.546        	7061.856          
+S2              	4046.392          	7061.856          
+S2              	3427.835          	3350.515          
+S2              	-1726.804         	3917.526          
+S2              	-2603.093         	8247.423          
+
+[SYMBOLS]
+;;Gage          	X-Coord           	Y-Coord           
+;;--------------	------------------	------------------
+1               	-15180.412        	7216.495          
+

--- a/pyswmm/tests/test_subcatchments.py
+++ b/pyswmm/tests/test_subcatchments.py
@@ -9,7 +9,9 @@
 # Local imports
 from pyswmm import Simulation, Subcatchments
 # from pyswmm.swmm5 import PySWMM
-from pyswmm.tests.data import MODEL_FULL_FEATURES_PATH, MODEL_WEIR_SETTING_PATH
+from pyswmm.tests.data import MODEL_FULL_FEATURES_PATH, MODEL_WEIR_SETTING_PATH, MODEL_SUBCATCH_STATS_PATH
+from pytest import approx
+UT_PRECISION = 1  # %
 
 
 def test_subcatchments_1():
@@ -35,6 +37,32 @@ def test_subcatchments_2():
             print(subcatchment.curb_length)
             subcatchment.curb_length = 10
             print(subcatchment.curb_length)
+
+
+
+def test_subcatchments_3():
+    with Simulation(MODEL_SUBCATCH_STATS_PATH) as sim:
+        S1 = Subcatchments(sim)['S1']
+        S2 = Subcatchments(sim)['S2']
+        for ind, step in enumerate(sim):
+            pass
+        
+        print(S1.statistics)
+        print(S2.statistics)
+
+        assert(S1.statistics['evaporation'] == approx(0.00, rel=UT_PRECISION)) # ft3
+        assert(S1.statistics['runoff'] == approx(1244.58, rel=UT_PRECISION)) # ft3
+        assert(S1.statistics['runon'] == approx(0.00, rel=UT_PRECISION)) # ft3
+        assert(S1.statistics['peak_runoff_rate'] == approx(0.12, rel=UT_PRECISION)) # cfs
+        assert(S1.statistics['infiltration'] == approx(0.00, rel=UT_PRECISION)) # ft3
+        assert(S1.statistics['precipitation'] == approx(0.12, rel=UT_PRECISION)) # in
+
+        assert(S2.statistics['evaporation'] == approx(0.00, rel=UT_PRECISION)) # ft3
+        assert(S2.statistics['runoff'] == approx(0.00, rel=UT_PRECISION)) # ft3
+        assert(S2.statistics['runon'] == approx(1207.74, rel=UT_PRECISION)) # ft3
+        assert(S2.statistics['peak_runoff_rate'] == approx(0.00, rel=UT_PRECISION)) #cfs
+        assert(S2.statistics['infiltration'] == approx(3476.57, rel=UT_PRECISION)) # ft3
+        assert(S2.statistics['precipitation'] == approx(0.12, rel=UT_PRECISION)) # in
 
 
 def test_nodes_3():


### PR DESCRIPTION
Closes #211 

-Update subcatch_statistics from single ptr to double ptr 
-Add an unit test
-TODO: should add a metric unit test in here..

units for the following variables:
 - precipitation [volume in depth] [in/mm]
 - runon [volume] [ft3/m3]
 - evaporation [volume] [ft3/m3]
 - infiltration [volume] [ft3/m3]
 - runoff [volume] [ft3/m3]
 - maxFlow [flow] [cfs/m3/s]

``` c
int DLLEXPORT swmm_getSubcatchStats(int index, SM_SubcatchStats **subcatchStats)
///
/// Output:  Subcatchment Stats Structure (SM_SubcatchStats)
/// Return:  API Error
/// Purpose: Gets Subcatchment Stats and Converts Units
{
``` 

