### PR TITLE
add wiki link to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,11 @@ GitHub and create a pull request.  All changes are welcome, big or small, and we
 will help you make the pull request if you are new to git
 (just ask on the issue).
 
+Contributing
+------------
+Please check out our Wiki https://github.com/OpenWaterAnalytics/pyswmm/wiki
+for more information on contributing, including an Author Contribution Checklist.
+
 License
 -------
 


### PR DESCRIPTION
Adds a link to the Wiki in the README for easy access to author contribution information. 

Closes #242 , which was submitted as part of a [JOSS review](https://github.com/openjournals/joss-reviews/issues/2292)