### PR TITLE
add sphinx documentation to gh pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,38 @@
+name: GH Pages Sphinx Docs
+on: [push, pull_request]
+  
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+            python-version: "3.10"
+            cache: "pip"
+     
+      - name: Install pyswmm
+        run: |
+          pip install -r requirements.txt -r docs/source/docs_requirements.txt
+          pip install -e .
+      
+      - name: Sphinx build
+        run: sphinx-build docs/source docs/build
+
+      # deploy docs      
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        # only deploy if pushing to master or merging PR into master
+        if: ${{ github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event.pull_request.merged == true)}}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/build
+          force_orphan: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,8 +29,8 @@ jobs:
       # deploy docs      
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        # only deploy if pushing to master or merging PR into master
-        if: ${{ github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event.pull_request.merged == true)}}
+        # only deploy if tagging a new version
+        if: startsWith(github.event.ref, 'refs/tags/v')
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.py }}
+          cache: "pip"
 
       - name: Install pyswmm
         run: |

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,6 +42,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
+    'sphinx.ext.githubpages',
     'sphinx.ext.intersphinx',
     'sphinx.ext.doctest',
     'sphinx.ext.todo',

--- a/docs/source/docs_requirements.txt
+++ b/docs/source/docs_requirements.txt
@@ -1,5 +1,7 @@
-pyswmm
+# docs requirements
+# python 3.10
 git+https://github.com/karosc/sphinx-panels
 pydata-sphinx-theme==0.12.0
 sphinx==5.3.0
 sphinx_copybutton==0.5.1
+ipython==8.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,5 @@
 wheel
 pytest
 julian==0.14
-swmm-toolkit==0.9.0
+swmm-toolkit==0.9.1
 aenum==3.1.11
-
-# docs requirements
-git+https://github.com/karosc/sphinx-panels
-pydata-sphinx-theme==0.12.0
-sphinx==5.3.0
-sphinx_copybutton==0.5.1


### PR DESCRIPTION
- new workflow for publish docs to gh-pages
	- docs are built whenever there is a push or PR event regardless of branch (to keep tabs on docs stability during development)
	- docs are only published when there is a push in to master or a merged PR into master. Makes deployed docs representative of current release since we should only push/merge to master right before a release.
- separate doc dependencies into separate file
- add caching to gh workflows
