### PR TITLE
Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+## [Unreleased]
+
+### Changed
+
+- Hardened `Output.verify_time()` validation to reject boolean indices, handle empty reporting timelines safely, and enforce datetime bounds against configured start/end values.
+
+### Added
+
+- Added regression tests for `verify_time()` covering start/end bound checks, empty time-list handling, and boolean index rejection.
+
 ## [2.1.0] - 2025-09-08
 
 Wake up and smell the coffee! We are back. Getting started with some basic maintenance. 

--- a/pyswmm/__init__.py
+++ b/pyswmm/__init__.py
@@ -19,7 +19,7 @@ from pyswmm.subcatchments import Subcatchment, Subcatchments
 from pyswmm.system import SystemStats
 from pyswmm.raingages import RainGages, RainGage
 
-VERSION_INFO = (2, 1, 0)
+VERSION_INFO = (2, 1, 1)
 
 __version__ = ".".join(map(str, VERSION_INFO))
 __author__ = "Bryant E. McDonnell (Hydroinformatics, LLC) - bemcdonnell@gmail.com"

--- a/pyswmm/output.py
+++ b/pyswmm/output.py
@@ -138,12 +138,13 @@ class Output(object):
         :rtype: int
         """
         max_index = len(time_list) - 1
-
+        first_time = time_list[0] if time_list else None
+        
         def _raise_out_of_range(arg):
             datetime_format = "%Y-%m-%d %H:%M:%S"
             msg = (
                 f"{arg} does not exist in model output reporting time steps."
-                f" The reporting time range is {start.strftime(datetime_format)} to "
+                f" The reporting time range is {first_time.strftime(datetime_format)} to "
                 f"{end.strftime(datetime_format)} at increments of {report} seconds."
                 f" Valid integer indices are 0..{max_index}."
             )
@@ -151,6 +152,7 @@ class Output(object):
 
         resolved = time_index if time_index is not None else default_time
 
+        # Cover before start, after end, and non-aligned datetimes
         if isinstance(resolved, datetime):
             # time_list is sorted; use binary search
             idx = bisect_left(time_list, resolved)
@@ -158,6 +160,7 @@ class Output(object):
                 return idx
             _raise_out_of_range(resolved)
 
+        # Cover indicies
         if isinstance(resolved, int):
             if 0 <= resolved <= max_index:
                 return resolved

--- a/pyswmm/output.py
+++ b/pyswmm/output.py
@@ -137,8 +137,13 @@ class Output(object):
         :return: The integer index of the given time
         :rtype: int
         """
-        first_time = time_list[0] if time_list else None
-        last_time = time_list[-1] if time_list else None
+        if not time_list:
+            raise OutputException(
+                "Model output contains no reporting time steps; cannot resolve time index."
+            )
+
+        first_time = time_list[0]
+        last_time = time_list[-1]
         max_index = len(time_list) - 1
 
         def _raise_out_of_range(arg):
@@ -155,6 +160,9 @@ class Output(object):
 
         # Cover before start, after end, and non-aligned datetimes
         if isinstance(resolved, datetime):
+            if resolved < start or resolved > end:
+                _raise_out_of_range(resolved)
+
             # time_list is sorted; use binary search
             idx = bisect_left(time_list, resolved)
             if 0 <= idx <= max_index and time_list[idx] == resolved:
@@ -162,6 +170,9 @@ class Output(object):
             _raise_out_of_range(resolved)
 
         # Cover indicies
+        if isinstance(resolved, bool):
+            _raise_out_of_range(resolved)
+
         if isinstance(resolved, int):
             if 0 <= resolved <= max_index:
                 return resolved

--- a/pyswmm/output.py
+++ b/pyswmm/output.py
@@ -10,10 +10,10 @@ from pyswmm.errors import OutputException
 from datetime import datetime, timedelta
 from functools import wraps
 from typing import NoReturn, Optional, Union
+from bisect import bisect_left
 
 # Third party imports
 from swmm.toolkit import output, shared_enum
-from julian import from_jd
 
 
 def output_open_handler(func):
@@ -137,7 +137,6 @@ class Output(object):
         :return: The integer index of the given time
         :rtype: int
         """
-
         max_index = len(time_list) - 1
 
         def _raise_out_of_range(arg):
@@ -153,8 +152,10 @@ class Output(object):
         resolved = time_index if time_index is not None else default_time
 
         if isinstance(resolved, datetime):
-            if resolved in time_list:
-                return time_list.index(resolved)
+            # time_list is sorted; use binary search
+            idx = bisect_left(time_list, resolved)
+            if 0 <= idx <= max_index and time_list[idx] == resolved:
+                return idx
             _raise_out_of_range(resolved)
 
         if isinstance(resolved, int):
@@ -178,7 +179,7 @@ class Output(object):
         if not self.loaded:
             self.loaded = True
             output.open(self.handle, self.binfile)
-            self.start = from_jd(output.get_start_date(self.handle) + 2415018.5)
+            self.start = datetime(*output.decode_date(output.get_start_date(self.handle))[:6])
             self.start = self.start.replace(microsecond=0)
             self.report = output.get_times(self.handle, shared_enum.Time.REPORT_STEP)
             self.period = output.get_times(self.handle, shared_enum.Time.NUM_PERIODS)
@@ -234,12 +235,16 @@ class Output(object):
             self._load_times()
         return self._times
 
+
     @output_open_handler
     def _load_times(self) -> NoReturn:
         """Load model reporting times into self._times"""
-        self._times = list()
-        for step in range(1, self.period + 1):
-            self._times.append(self.start + timedelta(seconds=self.report) * step)
+        # Read raw date values (double) and decode into Python datetimes
+        raw_dates = output.get_date_series(self.handle, 0, self.period - 1)
+        self._times = [
+            datetime(*output.decode_date(d)[:6]).replace(microsecond=0)
+            for d in raw_dates
+        ]
 
     @property
     def project_size(self) -> list:

--- a/pyswmm/output.py
+++ b/pyswmm/output.py
@@ -66,8 +66,8 @@ class Output(object):
         self.loaded = False
         self.delete_handle = False
         self.period = None
-        self.report = None
-        self.start = None
+        self.rpt_step = None
+        self.rpt_start = None
         self.end = None
         self._times = None
 
@@ -137,15 +137,16 @@ class Output(object):
         :return: The integer index of the given time
         :rtype: int
         """
-        max_index = len(time_list) - 1
         first_time = time_list[0] if time_list else None
-        
+        last_time = time_list[-1] if time_list else None
+        max_index = len(time_list) - 1
+
         def _raise_out_of_range(arg):
             datetime_format = "%Y-%m-%d %H:%M:%S"
             msg = (
                 f"{arg} does not exist in model output reporting time steps."
                 f" The reporting time range is {first_time.strftime(datetime_format)} to "
-                f"{end.strftime(datetime_format)} at increments of {report} seconds."
+                f"{last_time.strftime(datetime_format)} at increments of {report} seconds."
                 f" Valid integer indices are 0..{max_index}."
             )
             raise OutputException(msg)
@@ -182,19 +183,28 @@ class Output(object):
         if not self.loaded:
             self.loaded = True
             output.open(self.handle, self.binfile)
-            self.start = datetime(*output.decode_date(output.get_start_date(self.handle))[:6])
-            self.start = self.start.replace(microsecond=0)
-            self.report = output.get_times(self.handle, shared_enum.Time.REPORT_STEP)
-            self.period = output.get_times(self.handle, shared_enum.Time.NUM_PERIODS)
-            self.end = self.start + timedelta(seconds=self.period * self.report)
 
+            # Report metadata
+            self.rpt_start = datetime(*output.decode_date(output.get_start_date(self.handle))[:6])
+            self.rpt_start = self.rpt_start.replace(microsecond=0)
+            self.rpt_step = output.get_times(self.handle, shared_enum.Time.REPORT_STEP)
+            self.period = output.get_times(self.handle, shared_enum.Time.NUM_PERIODS)
+            
+            # Build reporting timeline from binary to avoid rounding drift
+            self._load_times()
+            if self._times:
+                # Use the last actual reporting timestamp as end
+                self.end = self._times[-1]
+            else:
+                # Fallback if no periods
+                self.end = self.rpt_start
         return True
 
     def close(self) -> bool:
         """
         Close an opened binary file
 
-        :returns: True if binary file was closed successfully
+        :returns: True if binary file was closed successfull`y
         :rtype: bool
         """
         if self.handle or self.loaded:
@@ -515,21 +525,21 @@ class Output(object):
         """
         index = self.verify_index(index, self.subcatchments, "subcatchment")
         start_index = self.verify_time(
-            start_index, self.times, self.start, self.end, self.report, 0
+            start_index, self.times, self.rpt_start, self.end, self.rpt_step, 0
         )
         # Determine inclusive end index; default to last valid index
         if end_index is None:
             end_idx = self.verify_time(
-                None, self.times, self.start, self.end, self.report, self.period - 1
+                None, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
             )
         elif end_exclusive:
             if isinstance(end_index, datetime):
                 tmp_end = self.verify_time(
                     end_index,
                     self.times,
-                    self.start,
+                    self.rpt_start,
                     self.end,
-                    self.report,
+                    self.rpt_step,
                     self.period - 1,
                 )
                 end_idx = tmp_end - 1
@@ -538,15 +548,15 @@ class Output(object):
             if end_idx < start_index:
                 return {}
             end_idx = self.verify_time(
-                end_idx, self.times, self.start, self.end, self.report, self.period - 1
+                end_idx, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
             )
         else:
             end_idx = self.verify_time(
                 end_index,
                 self.times,
-                self.start,
+                self.rpt_start,
                 self.end,
-                self.report,
+                self.rpt_step,
                 self.period - 1,
             )
 
@@ -607,21 +617,21 @@ class Output(object):
 
         index = self.verify_index(index, self.nodes, "node")
         start_index = self.verify_time(
-            start_index, self.times, self.start, self.end, self.report, 0
+            start_index, self.times, self.rpt_start, self.end, self.rpt_step, 0
         )
         # Determine inclusive end index; default to last valid index
         if end_index is None:
             end_idx = self.verify_time(
-                None, self.times, self.start, self.end, self.report, self.period - 1
+                None, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
             )
         elif end_exclusive:
             if isinstance(end_index, datetime):
                 tmp_end = self.verify_time(
                     end_index,
                     self.times,
-                    self.start,
+                    self.rpt_start,
                     self.end,
-                    self.report,
+                    self.rpt_step,
                     self.period - 1,
                 )
                 end_idx = tmp_end - 1
@@ -630,15 +640,15 @@ class Output(object):
             if end_idx < start_index:
                 return {}
             end_idx = self.verify_time(
-                end_idx, self.times, self.start, self.end, self.report, self.period - 1
+                end_idx, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
             )
         else:
             end_idx = self.verify_time(
                 end_index,
                 self.times,
-                self.start,
+                self.rpt_start,
                 self.end,
-                self.report,
+                self.rpt_step,
                 self.period - 1,
             )
 
@@ -698,21 +708,21 @@ class Output(object):
         """
         index = self.verify_index(index, self.links, "link")
         start_index = self.verify_time(
-            start_index, self.times, self.start, self.end, self.report, 0
+            start_index, self.times, self.rpt_start, self.end, self.rpt_step, 0
         )
         # Determine inclusive end index; default to last valid index
         if end_index is None:
             end_idx = self.verify_time(
-                None, self.times, self.start, self.end, self.report, self.period - 1
+                None, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
             )
         elif end_exclusive:
             if isinstance(end_index, datetime):
                 tmp_end = self.verify_time(
                     end_index,
                     self.times,
-                    self.start,
+                    self.rpt_start,
                     self.end,
-                    self.report,
+                    self.rpt_step,
                     self.period - 1,
                 )
                 end_idx = tmp_end - 1
@@ -721,15 +731,15 @@ class Output(object):
             if end_idx < start_index:
                 return {}
             end_idx = self.verify_time(
-                end_idx, self.times, self.start, self.end, self.report, self.period - 1
+                end_idx, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
             )
         else:
             end_idx = self.verify_time(
                 end_index,
                 self.times,
-                self.start,
+                self.rpt_start,
                 self.end,
-                self.report,
+                self.rpt_step,
                 self.period - 1,
             )
 
@@ -786,21 +796,21 @@ class Output(object):
         >>> 2015-11-01 15:03:00 0.022994007915258408
         """
         start_index = self.verify_time(
-            start_index, self.times, self.start, self.end, self.report, 0
+            start_index, self.times, self.rpt_start, self.end, self.rpt_step, 0
         )
         # Determine inclusive end index; default to last valid index
         if end_index is None:
             end_idx = self.verify_time(
-                None, self.times, self.start, self.end, self.report, self.period - 1
+                None, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
             )
         elif end_exclusive:
             if isinstance(end_index, datetime):
                 tmp_end = self.verify_time(
                     end_index,
                     self.times,
-                    self.start,
+                    self.rpt_start,
                     self.end,
-                    self.report,
+                    self.rpt_step,
                     self.period - 1,
                 )
                 end_idx = tmp_end - 1
@@ -809,15 +819,15 @@ class Output(object):
             if end_idx < start_index:
                 return {}
             end_idx = self.verify_time(
-                end_idx, self.times, self.start, self.end, self.report, self.period - 1
+                end_idx, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
             )
         else:
             end_idx = self.verify_time(
                 end_index,
                 self.times,
-                self.start,
+                self.rpt_start,
                 self.end,
-                self.report,
+                self.rpt_step,
                 self.period - 1,
             )
 
@@ -860,7 +870,7 @@ class Output(object):
         """
 
         time_index = self.verify_time(
-            time_index, self.times, self.start, self.end, self.report, 0
+            time_index, self.times, self.rpt_start, self.end, self.rpt_step, 0
         )
 
         values = output.get_subcatch_attribute(self.handle, time_index, attribute)
@@ -900,7 +910,7 @@ class Output(object):
         """
 
         time_index = self.verify_time(
-            time_index, self.times, self.start, self.end, self.report, 0
+            time_index, self.times, self.rpt_start, self.end, self.rpt_step, 0
         )
 
         values = output.get_node_attribute(self.handle, time_index, attribute)
@@ -939,7 +949,7 @@ class Output(object):
         """
 
         time_index = self.verify_time(
-            time_index, self.times, self.start, self.end, self.report, 0
+            time_index, self.times, self.rpt_start, self.end, self.rpt_step, 0
         )
 
         values = output.get_link_attribute(self.handle, time_index, attribute)
@@ -967,7 +977,7 @@ class Output(object):
     #     """
     #
     #     time_index = self.verify_time(
-    #         time_index, self.times, self.start, self.end, self.report, 0
+    #         time_index, self.times, self.rpt_start, self.end, self.rpt_step, 0
     #     )
     #
     #     value = output.get_system_attribute(self.handle, time_index, attribute)
@@ -1007,7 +1017,7 @@ class Output(object):
         """
         index = self.verify_index(index, self.subcatchments, "subcatchment")
         time_index = self.verify_time(
-            time_index, self.times, self.start, self.end, self.report, 0
+            time_index, self.times, self.rpt_start, self.end, self.rpt_step, 0
         )
 
         values = output.get_subcatch_result(self.handle, time_index, index)
@@ -1047,7 +1057,7 @@ class Output(object):
         """
         index = self.verify_index(index, self.nodes, "node")
         time_index = self.verify_time(
-            time_index, self.times, self.start, self.end, self.report, 0
+            time_index, self.times, self.rpt_start, self.end, self.rpt_step, 0
         )
 
         values = output.get_node_result(self.handle, time_index, index)
@@ -1084,7 +1094,7 @@ class Output(object):
         """
         index = self.verify_index(index, self.links, "link")
         time_index = self.verify_time(
-            time_index, self.times, self.start, self.end, self.report, 0
+            time_index, self.times, self.rpt_start, self.end, self.rpt_step, 0
         )
 
         values = output.get_link_result(self.handle, time_index, index)
@@ -1126,7 +1136,7 @@ class Output(object):
         """
         dummy_index = 0
         time_index = self.verify_time(
-            time_index, self.times, self.start, self.end, self.report, 0
+            time_index, self.times, self.rpt_start, self.end, self.rpt_step, 0
         )
 
         values = output.get_system_result(self.handle, time_index, dummy_index)

--- a/pyswmm/output.py
+++ b/pyswmm/output.py
@@ -185,11 +185,13 @@ class Output(object):
             output.open(self.handle, self.binfile)
 
             # Report metadata
-            self.rpt_start = datetime(*output.decode_date(output.get_start_date(self.handle))[:6])
+            self.rpt_start = datetime(
+                *output.decode_date(output.get_start_date(self.handle))[:6]
+            )
             self.rpt_start = self.rpt_start.replace(microsecond=0)
             self.rpt_step = output.get_times(self.handle, shared_enum.Time.REPORT_STEP)
             self.period = output.get_times(self.handle, shared_enum.Time.NUM_PERIODS)
-            
+
             # Build reporting timeline from binary to avoid rounding drift
             self._load_times()
             if self._times:
@@ -247,7 +249,6 @@ class Output(object):
         if self._times is None:
             self._load_times()
         return self._times
-
 
     @output_open_handler
     def _load_times(self) -> NoReturn:
@@ -530,7 +531,12 @@ class Output(object):
         # Determine inclusive end index; default to last valid index
         if end_index is None:
             end_idx = self.verify_time(
-                None, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
+                None,
+                self.times,
+                self.rpt_start,
+                self.end,
+                self.rpt_step,
+                self.period - 1,
             )
         elif end_exclusive:
             if isinstance(end_index, datetime):
@@ -548,7 +554,12 @@ class Output(object):
             if end_idx < start_index:
                 return {}
             end_idx = self.verify_time(
-                end_idx, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
+                end_idx,
+                self.times,
+                self.rpt_start,
+                self.end,
+                self.rpt_step,
+                self.period - 1,
             )
         else:
             end_idx = self.verify_time(
@@ -622,7 +633,12 @@ class Output(object):
         # Determine inclusive end index; default to last valid index
         if end_index is None:
             end_idx = self.verify_time(
-                None, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
+                None,
+                self.times,
+                self.rpt_start,
+                self.end,
+                self.rpt_step,
+                self.period - 1,
             )
         elif end_exclusive:
             if isinstance(end_index, datetime):
@@ -640,7 +656,12 @@ class Output(object):
             if end_idx < start_index:
                 return {}
             end_idx = self.verify_time(
-                end_idx, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
+                end_idx,
+                self.times,
+                self.rpt_start,
+                self.end,
+                self.rpt_step,
+                self.period - 1,
             )
         else:
             end_idx = self.verify_time(
@@ -713,7 +734,12 @@ class Output(object):
         # Determine inclusive end index; default to last valid index
         if end_index is None:
             end_idx = self.verify_time(
-                None, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
+                None,
+                self.times,
+                self.rpt_start,
+                self.end,
+                self.rpt_step,
+                self.period - 1,
             )
         elif end_exclusive:
             if isinstance(end_index, datetime):
@@ -731,7 +757,12 @@ class Output(object):
             if end_idx < start_index:
                 return {}
             end_idx = self.verify_time(
-                end_idx, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
+                end_idx,
+                self.times,
+                self.rpt_start,
+                self.end,
+                self.rpt_step,
+                self.period - 1,
             )
         else:
             end_idx = self.verify_time(
@@ -801,7 +832,12 @@ class Output(object):
         # Determine inclusive end index; default to last valid index
         if end_index is None:
             end_idx = self.verify_time(
-                None, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
+                None,
+                self.times,
+                self.rpt_start,
+                self.end,
+                self.rpt_step,
+                self.period - 1,
             )
         elif end_exclusive:
             if isinstance(end_index, datetime):
@@ -819,7 +855,12 @@ class Output(object):
             if end_idx < start_index:
                 return {}
             end_idx = self.verify_time(
-                end_idx, self.times, self.rpt_start, self.end, self.rpt_step, self.period - 1
+                end_idx,
+                self.times,
+                self.rpt_start,
+                self.end,
+                self.rpt_step,
+                self.period - 1,
             )
         else:
             end_idx = self.verify_time(

--- a/pyswmm/tests/data/__init__.py
+++ b/pyswmm/tests/data/__init__.py
@@ -14,6 +14,7 @@ import sys
 DATA_PATH = os.path.abspath(os.path.dirname(__file__))
 
 # Test models paths
+MODEL_DELAYED_REPORT_PATH = os.path.join(DATA_PATH, "model_delayed_report.inp")
 MODEL_NODE_INFLOWS_PATH = os.path.join(DATA_PATH, "model_node_inflows.inp")
 MODEL_PUMP_SETTINGS_PATH = os.path.join(DATA_PATH, "model_pump_setting.inp")
 MODEL_TOOLKIT_UNITS_PATH = os.path.join(DATA_PATH, "model_toolkit_units.inp")

--- a/pyswmm/tests/data/model_delayed_report.inp
+++ b/pyswmm/tests/data/model_delayed_report.inp
@@ -1,0 +1,278 @@
+[TITLE]
+
+
+[OPTIONS]
+;;Options            Value
+;;------------------ ------------
+FLOW_UNITS           CFS
+INFILTRATION         HORTON
+FLOW_ROUTING         DYNWAVE
+START_DATE           11/01/2015
+START_TIME           12:00:00
+REPORT_START_DATE    11/01/2015
+REPORT_START_TIME    14:00:00
+END_DATE             11/04/2015
+END_TIME             00:00:00
+SWEEP_START          01/01
+SWEEP_END            12/31
+DRY_DAYS             0
+REPORT_STEP          00:01:00
+WET_STEP             00:05:00
+DRY_STEP             00:05:00
+ROUTING_STEP         1
+ALLOW_PONDING        NO
+INERTIAL_DAMPING     NONE
+VARIABLE_STEP        0.75
+LENGTHENING_STEP     0
+MIN_SURFAREA         12.557
+NORMAL_FLOW_LIMITED  BOTH
+SKIP_STEADY_STATE    NO
+FORCE_MAIN_EQUATION  H-W
+LINK_OFFSETS         DEPTH
+MIN_SLOPE            0
+MAX_TRIALS           8
+HEAD_TOLERANCE       0.005
+SYS_FLOW_TOL         5
+LAT_FLOW_TOL         5
+MINIMUM_STEP         0.5
+THREADS              1
+
+[EVAPORATION]
+;;Type          Parameters
+;;------------- ----------
+CONSTANT     0.0
+DRY_ONLY     NO
+
+[RAINGAGES]
+;;                 Rain      Time   Snow   Data      
+;;Name             Type      Intrvl Catch  Source    
+;;---------------- --------- ------ ------ ----------
+SCS_24h_Type_I_1in INTENSITY 0:15   1.0    TIMESERIES SCS_24h_Type_I_1in
+
+[SUBCATCHMENTS]
+;;                                                 Total    Pcnt.             Pcnt.    Curb     Snow    
+;;Name           Raingage         Outlet           Area     Imperv   Width    Slope    Length   Pack    
+;;-------------- ---------------- ---------------- -------- -------- -------- -------- -------- --------
+S1               SCS_24h_Type_I_1in J1             1        100      500      0.5      0                        
+S2               SCS_24h_Type_I_1in J2             2        100      500      0.5      0                        
+S3               SCS_24h_Type_I_1in j3             3        100      500      0.5      0                        
+
+[SUBAREAS]
+;;Subcatchment   N-Imperv   N-Perv     S-Imperv   S-Perv     PctZero    RouteTo    PctRouted 
+;;-------------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
+S1               0.01       0.1        0.05       0.05       25         OUTLET    
+S2               0.01       0.1        0.05       0.05       25         OUTLET    
+S3               0.01       0.1        0.05       0.05       25         OUTLET    
+
+[INFILTRATION]
+;;Subcatchment   MaxRate    MinRate    Decay      DryTime    MaxInfil  
+;;-------------- ---------- ---------- ---------- ---------- ----------
+S1               3          0.5        4          7          0         
+S2               3          0.5        4          7          0         
+S3               3          0.5        4          7          0         
+
+[JUNCTIONS]
+;;               Invert     Max.       Init.      Surcharge  Ponded    
+;;Name           Elev.      Depth      Depth      Depth      Area      
+;;-------------- ---------- ---------- ---------- ---------- ----------
+J1               20.728     15         0          0          0         
+J2               13.392     15         0          0          0         
+J3               6.547      15         0          0          0         
+J5               27         10         0          0          0         
+
+[OUTFALLS]
+;;               Invert     Outfall      Stage/Table      Tide
+;;Name           Elev.      Type         Time Series      Gate Route To        
+;;-------------- ---------- ------------ ---------------- ---- ----------------
+J4               0          FREE                          NO                   
+
+[CONDUITS]
+;;               Inlet            Outlet                      Manning    Inlet      Outlet     Init.      Max.      
+;;Name           Node             Node             Length     N          Offset     Offset     Flow       Flow      
+;;-------------- ---------------- ---------------- ---------- ---------- ---------- ---------- ---------- ----------
+C1               J5               J1               251.49     0.01       0          0          0          0         
+C1:C2            J1               J2               244.63     0.01       0          0          0          0         
+C2               J2               J3               228.28     0.01       0          0          0          0         
+
+[WEIRS]
+;;               Inlet            Outlet           Weir         Crest      Disch.     Flap End      End       
+;;Name           Node             Node             Type         Height     Coeff.     Gate Con.     Coeff.     Surcharge  RoadWidth  RoadSurf  
+;;-------------- ---------------- ---------------- ------------ ---------- ---------- ---- -------- ---------- ---------- ---------- ----------
+C3               J3               J4               TRANSVERSE   0          3.33       NO   0        0          NO        
+
+[XSECTIONS]
+;;Link           Shape        Geom1            Geom2      Geom3      Geom4      Barrels   
+;;-------------- ------------ ---------------- ---------- ---------- ---------- ----------
+C1               CIRCULAR     1                0          0          0          1                    
+C1:C2            CIRCULAR     1                0          0          0          1                    
+C2               CIRCULAR     1.5              0          0          0          1                    
+C3               RECT_OPEN    5                1          0          0         
+
+[LOSSES]
+;;Link           Inlet      Outlet     Average    Flap Gate  SeepageRate
+;;-------------- ---------- ---------- ---------- ---------- ----------
+
+[INFLOWS]
+;;                                                 Param    Units    Scale    Baseline Baseline
+;;Node           Parameter        Time Series      Type     Factor   Factor   Value    Pattern
+;;-------------- ---------------- ---------------- -------- -------- -------- -------- --------
+J1               FLOW             ""               FLOW     1.0      1        1                
+J2               FLOW             ""               FLOW     1.0      1        1                
+J3               FLOW             ""               FLOW     1.0      1        1                
+
+[DWF]
+;;                                Average    Time      
+;;Node           Parameter        Value      Patterns  
+;;-------------- ---------------- ---------- ----------
+J1               FLOW             8          "" "" "" ""
+
+[TIMESERIES]
+;;Name           Date       Time       Value     
+;;-------------- ---------- ---------- ----------
+;SCS_24h_Type_I_1in design storm, total rainfall = 1 in, rain units = in/hr.
+SCS_24h_Type_I_1in            0:00       0.0175    
+SCS_24h_Type_I_1in            0:15       0.0175    
+SCS_24h_Type_I_1in            0:30       0.0175    
+SCS_24h_Type_I_1in            0:45       0.0175    
+SCS_24h_Type_I_1in            1:00       0.0175    
+SCS_24h_Type_I_1in            1:15       0.0175    
+SCS_24h_Type_I_1in            1:30       0.0175    
+SCS_24h_Type_I_1in            1:45       0.0175    
+SCS_24h_Type_I_1in            2:00       0.0205    
+SCS_24h_Type_I_1in            2:15       0.0205    
+SCS_24h_Type_I_1in            2:30       0.0205    
+SCS_24h_Type_I_1in            2:45       0.0205    
+SCS_24h_Type_I_1in            3:00       0.0205    
+SCS_24h_Type_I_1in            3:15       0.0205    
+SCS_24h_Type_I_1in            3:30       0.0205    
+SCS_24h_Type_I_1in            3:45       0.0205    
+SCS_24h_Type_I_1in            4:00       0.0245    
+SCS_24h_Type_I_1in            4:15       0.0245    
+SCS_24h_Type_I_1in            4:30       0.0245    
+SCS_24h_Type_I_1in            4:45       0.0245    
+SCS_24h_Type_I_1in            5:00       0.0245    
+SCS_24h_Type_I_1in            5:15       0.0245    
+SCS_24h_Type_I_1in            5:30       0.0245    
+SCS_24h_Type_I_1in            5:45       0.0245    
+SCS_24h_Type_I_1in            6:00       0.031     
+SCS_24h_Type_I_1in            6:15       0.031     
+SCS_24h_Type_I_1in            6:30       0.031     
+SCS_24h_Type_I_1in            6:45       0.031     
+SCS_24h_Type_I_1in            7:00       0.038     
+SCS_24h_Type_I_1in            7:15       0.038     
+SCS_24h_Type_I_1in            7:30       0.038     
+SCS_24h_Type_I_1in            7:45       0.038     
+SCS_24h_Type_I_1in            8:00       0.05      
+SCS_24h_Type_I_1in            8:15       0.05      
+SCS_24h_Type_I_1in            8:30       0.07      
+SCS_24h_Type_I_1in            8:45       0.07      
+SCS_24h_Type_I_1in            9:00       0.098     
+SCS_24h_Type_I_1in            9:15       0.098     
+SCS_24h_Type_I_1in            9:30       0.236     
+SCS_24h_Type_I_1in            9:45       0.612     
+SCS_24h_Type_I_1in            10:00      0.136     
+SCS_24h_Type_I_1in            10:15      0.136     
+SCS_24h_Type_I_1in            10:30      0.082     
+SCS_24h_Type_I_1in            10:45      0.082     
+SCS_24h_Type_I_1in            11:00      0.06      
+SCS_24h_Type_I_1in            11:15      0.06      
+SCS_24h_Type_I_1in            11:30      0.06      
+SCS_24h_Type_I_1in            11:45      0.052     
+SCS_24h_Type_I_1in            12:00      0.048     
+SCS_24h_Type_I_1in            12:15      0.048     
+SCS_24h_Type_I_1in            12:30      0.042     
+SCS_24h_Type_I_1in            12:45      0.042     
+SCS_24h_Type_I_1in            13:00      0.042     
+SCS_24h_Type_I_1in            13:15      0.042     
+SCS_24h_Type_I_1in            13:30      0.038     
+SCS_24h_Type_I_1in            13:45      0.038     
+SCS_24h_Type_I_1in            14:00      0.0315    
+SCS_24h_Type_I_1in            14:15      0.0315    
+SCS_24h_Type_I_1in            14:30      0.0315    
+SCS_24h_Type_I_1in            14:45      0.0315    
+SCS_24h_Type_I_1in            15:00      0.0315    
+SCS_24h_Type_I_1in            15:15      0.0315    
+SCS_24h_Type_I_1in            15:30      0.0315    
+SCS_24h_Type_I_1in            15:45      0.0315    
+SCS_24h_Type_I_1in            16:00      0.024     
+SCS_24h_Type_I_1in            16:15      0.024     
+SCS_24h_Type_I_1in            16:30      0.024     
+SCS_24h_Type_I_1in            16:45      0.024     
+SCS_24h_Type_I_1in            17:00      0.024     
+SCS_24h_Type_I_1in            17:15      0.024     
+SCS_24h_Type_I_1in            17:30      0.024     
+SCS_24h_Type_I_1in            17:45      0.024     
+SCS_24h_Type_I_1in            18:00      0.024     
+SCS_24h_Type_I_1in            18:15      0.024     
+SCS_24h_Type_I_1in            18:30      0.024     
+SCS_24h_Type_I_1in            18:45      0.024     
+SCS_24h_Type_I_1in            19:00      0.024     
+SCS_24h_Type_I_1in            19:15      0.024     
+SCS_24h_Type_I_1in            19:30      0.024     
+SCS_24h_Type_I_1in            19:45      0.024     
+SCS_24h_Type_I_1in            20:00      0.0185    
+SCS_24h_Type_I_1in            20:15      0.0185    
+SCS_24h_Type_I_1in            20:30      0.0185    
+SCS_24h_Type_I_1in            20:45      0.0185    
+SCS_24h_Type_I_1in            21:00      0.0185    
+SCS_24h_Type_I_1in            21:15      0.0185    
+SCS_24h_Type_I_1in            21:30      0.0185    
+SCS_24h_Type_I_1in            21:45      0.0185    
+SCS_24h_Type_I_1in            22:00      0.0185    
+SCS_24h_Type_I_1in            22:15      0.0185    
+SCS_24h_Type_I_1in            22:30      0.0185    
+SCS_24h_Type_I_1in            22:45      0.0185    
+SCS_24h_Type_I_1in            23:00      0.0185    
+SCS_24h_Type_I_1in            23:15      0.0185    
+SCS_24h_Type_I_1in            23:30      0.0185    
+SCS_24h_Type_I_1in            23:45      0.0185    
+SCS_24h_Type_I_1in            24:00      0         
+
+[REPORT]
+INPUT      YES
+CONTROLS   YES
+SUBCATCHMENTS ALL
+NODES ALL
+LINKS ALL
+
+[TAGS]
+
+[MAP]
+DIMENSIONS       -294.855520781491 -181.9785        717.402739084833 213.8785        
+UNITS            Feet
+
+[COORDINATES]
+;;Node           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+J1               0                0               
+J2               238.75           -53.332         
+J3               459.058          -113.145        
+J5               -248.844         36.408          
+J4               671.391          -163.985        
+
+[VERTICES]
+;;Link           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+
+[POLYGONS]
+;;Subcatchment   X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+S1               110.154          195.885         
+S1               110.154          47.351          
+S1               -56.323          42.367          
+S1               -63.301          181.928         
+S1               110.154          195.885         
+S2               394.261          131.088         
+S2               410.211          -20.436         
+S2               245.728          -19.439         
+S2               235.759          110.154         
+S2               394.261          131.088         
+S3               660.425          55.326          
+S3               657.435          -104.173        
+S3               519.867          -96.198         
+S3               509.898          50.342          
+S3               660.425          55.326          
+
+[SYMBOLS]
+;;Gage           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------

--- a/pyswmm/tests/data/model_weir_setting_a.inp
+++ b/pyswmm/tests/data/model_weir_setting_a.inp
@@ -1,0 +1,278 @@
+[TITLE]
+
+
+[OPTIONS]
+;;Options            Value
+;;------------------ ------------
+FLOW_UNITS           CFS
+INFILTRATION         HORTON
+FLOW_ROUTING         DYNWAVE
+START_DATE           11/01/2015
+START_TIME           14:00:00
+REPORT_START_DATE    11/01/2015
+REPORT_START_TIME    14:00:00
+END_DATE             11/04/2015
+END_TIME             00:00:00
+SWEEP_START          01/01
+SWEEP_END            12/31
+DRY_DAYS             0
+REPORT_STEP          00:01:00
+WET_STEP             00:05:00
+DRY_STEP             00:05:00
+ROUTING_STEP         1
+ALLOW_PONDING        NO
+INERTIAL_DAMPING     NONE
+VARIABLE_STEP        0.75
+LENGTHENING_STEP     0
+MIN_SURFAREA         12.557
+NORMAL_FLOW_LIMITED  BOTH
+SKIP_STEADY_STATE    NO
+FORCE_MAIN_EQUATION  H-W
+LINK_OFFSETS         DEPTH
+MIN_SLOPE            0
+MAX_TRIALS           8
+HEAD_TOLERANCE       0.005
+SYS_FLOW_TOL         5
+LAT_FLOW_TOL         5
+MINIMUM_STEP         0.5
+THREADS              1
+
+[EVAPORATION]
+;;Type          Parameters
+;;------------- ----------
+CONSTANT     0.0
+DRY_ONLY     NO
+
+[RAINGAGES]
+;;                 Rain      Time   Snow   Data      
+;;Name             Type      Intrvl Catch  Source    
+;;---------------- --------- ------ ------ ----------
+SCS_24h_Type_I_1in INTENSITY 0:15   1.0    TIMESERIES SCS_24h_Type_I_1in
+
+[SUBCATCHMENTS]
+;;                                                 Total    Pcnt.             Pcnt.    Curb     Snow    
+;;Name           Raingage         Outlet           Area     Imperv   Width    Slope    Length   Pack    
+;;-------------- ---------------- ---------------- -------- -------- -------- -------- -------- --------
+S1     SCS_24h_Type_I_1in     J2     1     100     500     0.5     0
+S2               SCS_24h_Type_I_1in J2             2        100      500      0.5      0
+S3               SCS_24h_Type_I_1in j3             3        100      500      0.5      0
+
+[SUBAREAS]
+;;Subcatchment   N-Imperv   N-Perv     S-Imperv   S-Perv     PctZero    RouteTo    PctRouted 
+;;-------------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
+S1               0.01       0.1        0.05       0.05       25         OUTLET    
+S2               0.01       0.1        0.05       0.05       25         OUTLET    
+S3               0.01       0.1        0.05       0.05       25         OUTLET    
+
+[INFILTRATION]
+;;Subcatchment   MaxRate    MinRate    Decay      DryTime    MaxInfil  
+;;-------------- ---------- ---------- ---------- ---------- ----------
+S1               3          0.5        4          7          0         
+S2               3          0.5        4          7          0         
+S3               3          0.5        4          7          0         
+
+[JUNCTIONS]
+;;               Invert     Max.       Init.      Surcharge  Ponded    
+;;Name           Elev.      Depth      Depth      Depth      Area      
+;;-------------- ---------- ---------- ---------- ---------- ----------
+J1               20.728     15         0          0          0         
+J2               13.392     15         0          0          0         
+J3               6.547      15         0          0          0         
+J5               27         10         0          0          0         
+
+[OUTFALLS]
+;;               Invert     Outfall      Stage/Table      Tide
+;;Name           Elev.      Type         Time Series      Gate Route To        
+;;-------------- ---------- ------------ ---------------- ---- ----------------
+J4               0          FREE                          NO                   
+
+[CONDUITS]
+;;               Inlet            Outlet                      Manning    Inlet      Outlet     Init.      Max.      
+;;Name           Node             Node             Length     N          Offset     Offset     Flow       Flow      
+;;-------------- ---------------- ---------------- ---------- ---------- ---------- ---------- ---------- ----------
+C1               J5               J1               251.49     0.01       0          0          0          0         
+C1:C2            J1               J2               244.63     0.01       0          0          0          0         
+C2               J2               J3               228.28     0.01       0          0          0          0         
+
+[WEIRS]
+;;               Inlet            Outlet           Weir         Crest      Disch.     Flap End      End       
+;;Name           Node             Node             Type         Height     Coeff.     Gate Con.     Coeff.     Surcharge  RoadWidth  RoadSurf  
+;;-------------- ---------------- ---------------- ------------ ---------- ---------- ---- -------- ---------- ---------- ---------- ----------
+C3               J3               J4               TRANSVERSE   0          3.33       NO   0        0          NO        
+
+[XSECTIONS]
+;;Link           Shape        Geom1            Geom2      Geom3      Geom4      Barrels   
+;;-------------- ------------ ---------------- ---------- ---------- ---------- ----------
+C1               CIRCULAR     1                0          0          0          1                    
+C1:C2            CIRCULAR     1                0          0          0          1                    
+C2               CIRCULAR     1.5              0          0          0          1                    
+C3               RECT_OPEN    5                1          0          0         
+
+[LOSSES]
+;;Link           Inlet      Outlet     Average    Flap Gate  SeepageRate
+;;-------------- ---------- ---------- ---------- ---------- ----------
+
+[INFLOWS]
+;;                                                 Param    Units    Scale    Baseline Baseline
+;;Node           Parameter        Time Series      Type     Factor   Factor   Value    Pattern
+;;-------------- ---------------- ---------------- -------- -------- -------- -------- --------
+J1               FLOW             ""               FLOW     1.0      1        1                
+J2               FLOW             ""               FLOW     1.0      1        1                
+J3               FLOW             ""               FLOW     1.0      1        1                
+
+[DWF]
+;;                                Average    Time      
+;;Node           Parameter        Value      Patterns  
+;;-------------- ---------------- ---------- ----------
+J1               FLOW             8          "" "" "" ""
+
+[TIMESERIES]
+;;Name           Date       Time       Value     
+;;-------------- ---------- ---------- ----------
+;SCS_24h_Type_I_1in design storm, total rainfall = 1 in, rain units = in/hr.
+SCS_24h_Type_I_1in            0:00       0.0175
+SCS_24h_Type_I_1in            0:15       0.0175
+SCS_24h_Type_I_1in            0:30       0.0175
+SCS_24h_Type_I_1in            0:45       0.0175
+SCS_24h_Type_I_1in            1:00       0.0175
+SCS_24h_Type_I_1in     1:15     2.0
+SCS_24h_Type_I_1in            1:30       0.0175
+SCS_24h_Type_I_1in            1:45       0.0175
+SCS_24h_Type_I_1in            2:00       0.0205
+SCS_24h_Type_I_1in            2:15       0.0205
+SCS_24h_Type_I_1in            2:30       0.0205
+SCS_24h_Type_I_1in            2:45       0.0205
+SCS_24h_Type_I_1in            3:00       0.0205
+SCS_24h_Type_I_1in            3:15       0.0205
+SCS_24h_Type_I_1in            3:30       0.0205
+SCS_24h_Type_I_1in            3:45       0.0205
+SCS_24h_Type_I_1in            4:00       0.0245
+SCS_24h_Type_I_1in            4:15       0.0245
+SCS_24h_Type_I_1in            4:30       0.0245
+SCS_24h_Type_I_1in            4:45       0.0245
+SCS_24h_Type_I_1in            5:00       0.0245
+SCS_24h_Type_I_1in            5:15       0.0245
+SCS_24h_Type_I_1in            5:30       0.0245
+SCS_24h_Type_I_1in            5:45       0.0245
+SCS_24h_Type_I_1in            6:00       0.031
+SCS_24h_Type_I_1in            6:15       0.031
+SCS_24h_Type_I_1in            6:30       0.031
+SCS_24h_Type_I_1in            6:45       0.031
+SCS_24h_Type_I_1in            7:00       0.038
+SCS_24h_Type_I_1in            7:15       0.038
+SCS_24h_Type_I_1in            7:30       0.038
+SCS_24h_Type_I_1in            7:45       0.038
+SCS_24h_Type_I_1in            8:00       0.05
+SCS_24h_Type_I_1in            8:15       0.05
+SCS_24h_Type_I_1in            8:30       0.07
+SCS_24h_Type_I_1in            8:45       0.07
+SCS_24h_Type_I_1in            9:00       0.098
+SCS_24h_Type_I_1in            9:15       0.098
+SCS_24h_Type_I_1in            9:30       0.236
+SCS_24h_Type_I_1in            9:45       0.612
+SCS_24h_Type_I_1in            10:00      0.136
+SCS_24h_Type_I_1in            10:15      0.136
+SCS_24h_Type_I_1in            10:30      0.082
+SCS_24h_Type_I_1in            10:45      0.082
+SCS_24h_Type_I_1in            11:00      0.06
+SCS_24h_Type_I_1in            11:15      0.06
+SCS_24h_Type_I_1in            11:30      0.06
+SCS_24h_Type_I_1in            11:45      0.052
+SCS_24h_Type_I_1in            12:00      0.048
+SCS_24h_Type_I_1in            12:15      0.048
+SCS_24h_Type_I_1in            12:30      0.042
+SCS_24h_Type_I_1in            12:45      0.042
+SCS_24h_Type_I_1in            13:00      0.042
+SCS_24h_Type_I_1in            13:15      0.042
+SCS_24h_Type_I_1in            13:30      0.038
+SCS_24h_Type_I_1in            13:45      0.038
+SCS_24h_Type_I_1in            14:00      0.0315
+SCS_24h_Type_I_1in            14:15      0.0315
+SCS_24h_Type_I_1in            14:30      0.0315
+SCS_24h_Type_I_1in            14:45      0.0315
+SCS_24h_Type_I_1in            15:00      0.0315
+SCS_24h_Type_I_1in            15:15      0.0315
+SCS_24h_Type_I_1in            15:30      0.0315
+SCS_24h_Type_I_1in            15:45      0.0315
+SCS_24h_Type_I_1in            16:00      0.024
+SCS_24h_Type_I_1in            16:15      0.024
+SCS_24h_Type_I_1in            16:30      0.024
+SCS_24h_Type_I_1in            16:45      0.024
+SCS_24h_Type_I_1in            17:00      0.024
+SCS_24h_Type_I_1in            17:15      0.024
+SCS_24h_Type_I_1in            17:30      0.024
+SCS_24h_Type_I_1in            17:45      0.024
+SCS_24h_Type_I_1in            18:00      0.024
+SCS_24h_Type_I_1in            18:15      0.024
+SCS_24h_Type_I_1in            18:30      0.024
+SCS_24h_Type_I_1in            18:45      0.024
+SCS_24h_Type_I_1in            19:00      0.024
+SCS_24h_Type_I_1in            19:15      0.024
+SCS_24h_Type_I_1in            19:30      0.024
+SCS_24h_Type_I_1in            19:45      0.024
+SCS_24h_Type_I_1in            20:00      0.0185
+SCS_24h_Type_I_1in            20:15      0.0185
+SCS_24h_Type_I_1in            20:30      0.0185
+SCS_24h_Type_I_1in            20:45      0.0185
+SCS_24h_Type_I_1in            21:00      0.0185
+SCS_24h_Type_I_1in            21:15      0.0185
+SCS_24h_Type_I_1in            21:30      0.0185
+SCS_24h_Type_I_1in            21:45      0.0185
+SCS_24h_Type_I_1in            22:00      0.0185
+SCS_24h_Type_I_1in            22:15      0.0185
+SCS_24h_Type_I_1in            22:30      0.0185
+SCS_24h_Type_I_1in            22:45      0.0185
+SCS_24h_Type_I_1in            23:00      0.0185
+SCS_24h_Type_I_1in            23:15      0.0185
+SCS_24h_Type_I_1in            23:30      0.0185
+SCS_24h_Type_I_1in            23:45      0.0185
+SCS_24h_Type_I_1in            24:00      0
+
+[REPORT]
+INPUT      YES
+CONTROLS   YES
+SUBCATCHMENTS ALL
+NODES ALL
+LINKS ALL
+
+[TAGS]
+
+[MAP]
+DIMENSIONS       -294.855520781491 -181.9785        717.402739084833 213.8785        
+UNITS            Feet
+
+[COORDINATES]
+;;Node           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+J1               0                0               
+J2               238.75           -53.332         
+J3               459.058          -113.145        
+J5               -248.844         36.408          
+J4               671.391          -163.985        
+
+[VERTICES]
+;;Link           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+
+[POLYGONS]
+;;Subcatchment   X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+S1               110.154          195.885         
+S1               110.154          47.351          
+S1               -56.323          42.367          
+S1               -63.301          181.928         
+S1               110.154          195.885         
+S2               394.261          131.088         
+S2               410.211          -20.436         
+S2               245.728          -19.439         
+S2               235.759          110.154         
+S2               394.261          131.088         
+S3               660.425          55.326          
+S3               657.435          -104.173        
+S3               519.867          -96.198         
+S3               509.898          50.342          
+S3               660.425          55.326          
+
+[SYMBOLS]
+;;Gage           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------

--- a/pyswmm/tests/test_output.py
+++ b/pyswmm/tests/test_output.py
@@ -18,7 +18,7 @@ from swmm.toolkit.shared_enum import (
     SubcatchAttribute,
     SystemAttribute,
 )
-from datetime import datetime
+from datetime import datetime, timedelta
 from swmm.toolkit import output as tk_output
 
 
@@ -169,6 +169,33 @@ def test_times_loaded_from_binary():
         assert out.times == decoded
 
 
+def test_times_sequence_properties():
+    # Produce the output file
+    with Simulation(MODEL_WEIR_SETTING_PATH) as sim:
+        for _ in sim:
+            pass
+
+    with Output(MODEL_WEIR_SETTING_PATH.replace("inp", "out")) as out:
+        times = out.times
+
+        # Basic properties
+        assert isinstance(times, list)
+        assert len(times) == out.period
+        assert all(t.microsecond == 0 for t in times)
+
+        # Start time is non-inclusive; index 0 is start + report
+        assert times[0] == out.start + timedelta(seconds=out.report)
+
+        # Last timestamp equals end (end inclusive)
+        assert times[-1] == out.end
+
+        # Monotonic with constant step equal to report seconds
+        step_secs = [
+            (times[i + 1] - times[i]).total_seconds() for i in range(len(times) - 1)
+        ]
+        assert all(s == out.report for s in step_secs)
+
+
 def test_verify_time_binary_search_datetime():
     with Simulation(MODEL_WEIR_SETTING_PATH) as sim:
         for step in sim:
@@ -182,3 +209,17 @@ def test_verify_time_binary_search_datetime():
         assert idx == mid
         # None defaults to 0
         assert Output.verify_time(None, out.times, out.start, out.end, out.report, 0) == 0
+
+
+def test_verify_time_datetime_before_start():
+    # Produce output
+    with Simulation(MODEL_WEIR_SETTING_PATH) as sim:
+        for _ in sim:
+            pass
+
+    # Verify a timestamp equal to model start is rejected (not a reporting time)
+    with Output(MODEL_WEIR_SETTING_PATH.replace("inp", "out")) as out:
+        bad_dt = out.start
+        with pytest.raises(OutputException) as exc:
+            Output.verify_time(bad_dt, out.times, out.start, out.end, out.report, 0)
+        assert "does not exist in model output reporting time steps." in str(exc.value)

--- a/pyswmm/tests/test_output.py
+++ b/pyswmm/tests/test_output.py
@@ -9,7 +9,7 @@ import pytest
 
 from pyswmm import Simulation
 from pyswmm import Output, SubcatchSeries, NodeSeries, LinkSeries, SystemSeries
-from pyswmm.tests.data import MODEL_WEIR_SETTING_PATH
+from pyswmm.tests.data import MODEL_DELAYED_REPORT_PATH, MODEL_WEIR_SETTING_PATH
 from pyswmm.errors import OutputException
 
 from swmm.toolkit.shared_enum import (
@@ -183,8 +183,8 @@ def test_times_sequence_properties():
         assert len(times) == out.period
         assert all(t.microsecond == 0 for t in times)
 
-        # Start time is non-inclusive; index 0 is start + report
-        assert times[0] == out.start + timedelta(seconds=out.report)
+        # Start time is non-inclusive; index 0 is rpt_start + rpt_step
+        assert times[0] == (out.rpt_start + timedelta(seconds=out.rpt_step))
 
         # Last timestamp equals end (end inclusive)
         assert times[-1] == out.end
@@ -193,7 +193,34 @@ def test_times_sequence_properties():
         step_secs = [
             (times[i + 1] - times[i]).total_seconds() for i in range(len(times) - 1)
         ]
-        assert all(s == out.report for s in step_secs)
+        assert all(s == out.rpt_step for s in step_secs)
+
+
+def test_delayed_start_sequence_props():
+    # Produce the output file
+    with Simulation(MODEL_DELAYED_REPORT_PATH) as sim:
+        for _ in sim:
+            pass
+
+    with Output(MODEL_DELAYED_REPORT_PATH.replace("inp", "out")) as out:
+        times = out.times
+
+        # Basic properties
+        assert isinstance(times, list)
+        assert len(times) == out.period
+        assert all(t.microsecond == 0 for t in times)
+
+        # Start time is non-inclusive; index 0 is rpt_start + rpt_step
+        assert times[0] == (out.rpt_start + timedelta(seconds=out.rpt_step))
+
+        # Last timestamp equals end (end inclusive)
+        assert times[-1] == out.end
+
+        # Monotonic with constant step equal to report seconds
+        step_secs = [
+            (times[i + 1] - times[i]).total_seconds() for i in range(len(times) - 1)
+        ]
+        assert all(s == out.rpt_step for s in step_secs)
 
 
 def test_verify_time_binary_search_datetime():
@@ -205,10 +232,10 @@ def test_verify_time_binary_search_datetime():
         # Pick a middle timestamp and ensure verify_time finds it
         mid = len(out.times) // 2
         dt = out.times[mid]
-        idx = Output.verify_time(dt, out.times, out.start, out.end, out.report, 0)
+        idx = Output.verify_time(dt, out.times, out.rpt_start, out.end, out.rpt_step, 0)
         assert idx == mid
         # None defaults to 0
-        assert Output.verify_time(None, out.times, out.start, out.end, out.report, 0) == 0
+        assert Output.verify_time(None, out.times, out.rpt_start, out.end, out.rpt_step, 0) == 0
 
 
 def test_verify_time_datetime_before_start():
@@ -219,7 +246,42 @@ def test_verify_time_datetime_before_start():
 
     # Verify a timestamp equal to model start is rejected (not a reporting time)
     with Output(MODEL_WEIR_SETTING_PATH.replace("inp", "out")) as out:
-        bad_dt = out.start
+        bad_dt = out.rpt_start
         with pytest.raises(OutputException) as exc:
-            Output.verify_time(bad_dt, out.times, out.start, out.end, out.report, 0)
+            Output.verify_time(bad_dt, out.times, out.rpt_start, out.end, out.rpt_step, 0)
         assert "does not exist in model output reporting time steps." in str(exc.value)
+
+
+def test_verify_time_with_report_delay():
+    # Produce the output file (simulation start != report start)
+    with Simulation(MODEL_DELAYED_REPORT_PATH) as sim:
+        for _ in sim:
+            pass
+
+    with Output(MODEL_DELAYED_REPORT_PATH.replace("inp", "out")) as out:
+        # Times are aligned to report step and built from the binary
+        assert isinstance(out.times, list)
+        assert len(out.times) == out.period
+
+        temp_out = out.node_series("J2", NodeAttribute.TOTAL_INFLOW)
+        assert len(temp_out) == out.period
+
+        # Non-inclusive start: index 0 == (report_start + report)
+        # assert out.times[0] == out.start + timedelta(seconds=out.report)
+        # assert out.times[-1] == out.end
+
+        # verify_time returns indices for valid datetimes
+        assert Output.verify_time(out.times[0], out.times, out.rpt_start, out.end, out.rpt_step, 0) == 0
+        assert Output.verify_time(out.times[-1], out.times, out.rpt_start, out.end, out.rpt_step, 0) == len(out.times) - 1
+
+        # Requesting the (non-inclusive) report start should fail with a clear message
+        implied_report_start = out.times[0] - timedelta(seconds=out.rpt_step)
+        with pytest.raises(OutputException) as exc:
+            Output.verify_time(implied_report_start, out.times, out.rpt_start, out.end, out.rpt_step, 0)
+        msg = str(exc.value).lower()
+        assert "does not exist" in msg #or "index 0" in msg
+
+        # Non-aligned datetime between start and first reporting time should fail
+        bad_dt = implied_report_start + timedelta(seconds=1)
+        with pytest.raises(OutputException):
+            Output.verify_time(bad_dt, out.times, out.rpt_start, out.end, out.rpt_step, 0)

--- a/pyswmm/tests/test_output.py
+++ b/pyswmm/tests/test_output.py
@@ -251,6 +251,44 @@ def test_verify_time_datetime_before_start():
             Output.verify_time(bad_dt, out.times, out.rpt_start, out.end, out.rpt_step, 0)
         assert "does not exist in model output reporting time steps." in str(exc.value)
 
+def test_verify_time():
+    # Produce the output file (simulation start != report start)
+    with Simulation(MODEL_WEIR_SETTING_PATH) as sim:
+        for _ in sim:
+            pass
+
+    with Output(MODEL_WEIR_SETTING_PATH.replace("inp", "out")) as out:
+        # Times are aligned to report step and built from the binary
+        assert isinstance(out.times, list)
+        assert len(out.times) == out.period
+
+        temp_out = out.node_series("J2", NodeAttribute.TOTAL_INFLOW)
+        assert len(temp_out) == out.period
+
+        # Non-inclusive start: index 0 == (report_start + report)
+        assert out.times[0] == out.rpt_start + timedelta(seconds=out.rpt_step)
+        assert out.times[-1] == out.end
+
+        # Requesting the (non-inclusive) report start should fail with a clear message
+        with pytest.raises(OutputException):
+            temp_out = out.node_series("J2", NodeAttribute.TOTAL_INFLOW, out.rpt_start, out.end)
+
+        # verify_time returns indices for valid datetimes
+        assert Output.verify_time(out.times[0], out.times, out.rpt_start, out.end, out.rpt_step, 0) == 0
+        assert Output.verify_time(out.times[-1], out.times, out.rpt_start, out.end, out.rpt_step, 0) == len(out.times) - 1
+
+        # Requesting the (non-inclusive) report start should fail with a clear message
+        implied_report_start = out.times[0] - timedelta(seconds=out.rpt_step)
+        with pytest.raises(OutputException) as exc:
+            Output.verify_time(implied_report_start, out.times, out.rpt_start, out.end, out.rpt_step, 0)
+        msg = str(exc.value).lower()
+        assert "does not exist" in msg #or "index 0" in msg
+
+        # Non-aligned datetime between start and first reporting time should fail
+        bad_dt = implied_report_start + timedelta(seconds=1)
+        with pytest.raises(OutputException):
+            Output.verify_time(bad_dt, out.times, out.rpt_start, out.end, out.rpt_step, 0)
+
 
 def test_verify_time_with_report_delay():
     # Produce the output file (simulation start != report start)
@@ -267,8 +305,12 @@ def test_verify_time_with_report_delay():
         assert len(temp_out) == out.period
 
         # Non-inclusive start: index 0 == (report_start + report)
-        # assert out.times[0] == out.start + timedelta(seconds=out.report)
-        # assert out.times[-1] == out.end
+        assert out.times[0] == out.rpt_start + timedelta(seconds=out.rpt_step)
+        assert out.times[-1] == out.end
+        
+        # Requesting the (non-inclusive) report start should fail with a clear message
+        with pytest.raises(OutputException):
+            temp_out = out.node_series("J2", NodeAttribute.TOTAL_INFLOW, out.rpt_start, out.end)
 
         # verify_time returns indices for valid datetimes
         assert Output.verify_time(out.times[0], out.times, out.rpt_start, out.end, out.rpt_step, 0) == 0

--- a/pyswmm/tests/test_output.py
+++ b/pyswmm/tests/test_output.py
@@ -367,3 +367,43 @@ def test_verify_time_with_report_delay():
             Output.verify_time(
                 bad_dt, out.times, out.rpt_start, out.end, out.rpt_step, 0
             )
+
+
+def test_verify_time_rejects_bool_index():
+    base = datetime(2020, 1, 1, 0, 1)
+    times = [base + timedelta(minutes=i) for i in range(3)]
+    start = base - timedelta(minutes=1)
+    end = times[-1]
+
+    with pytest.raises(OutputException):
+        Output.verify_time(True, times, start, end, 60, 0)
+
+    with pytest.raises(OutputException):
+        Output.verify_time(False, times, start, end, 60, 0)
+
+
+def test_verify_time_empty_time_list_raises():
+    with pytest.raises(OutputException) as exc:
+        Output.verify_time(
+            datetime(2020, 1, 1, 0, 1),
+            [],
+            datetime(2020, 1, 1, 0, 0),
+            datetime(2020, 1, 1, 0, 2),
+            60,
+            0,
+        )
+
+    assert "contains no reporting time steps" in str(exc.value).lower()
+
+
+def test_verify_time_honors_start_end_bounds():
+    base = datetime(2020, 1, 1, 0, 1)
+    times = [base + timedelta(minutes=i) for i in range(3)]
+
+    # Start excludes first element even if present in time_list
+    with pytest.raises(OutputException):
+        Output.verify_time(times[0], times, times[1], times[-1], 60, 0)
+
+    # End excludes last element if configured earlier than time_list max
+    with pytest.raises(OutputException):
+        Output.verify_time(times[-1], times, times[0], times[1], 60, 0)

--- a/pyswmm/tests/test_output.py
+++ b/pyswmm/tests/test_output.py
@@ -165,7 +165,9 @@ def test_times_loaded_from_binary():
     # Verify out.times equals toolkit-decoded date series
     with Output(MODEL_WEIR_SETTING_PATH.replace("inp", "out")) as out:
         raw = tk_output.get_date_series(out.handle, 0, out.period - 1)
-        decoded = [datetime(*tk_output.decode_date(d)[:6]).replace(microsecond=0) for d in raw]
+        decoded = [
+            datetime(*tk_output.decode_date(d)[:6]).replace(microsecond=0) for d in raw
+        ]
         assert out.times == decoded
 
 
@@ -235,7 +237,10 @@ def test_verify_time_binary_search_datetime():
         idx = Output.verify_time(dt, out.times, out.rpt_start, out.end, out.rpt_step, 0)
         assert idx == mid
         # None defaults to 0
-        assert Output.verify_time(None, out.times, out.rpt_start, out.end, out.rpt_step, 0) == 0
+        assert (
+            Output.verify_time(None, out.times, out.rpt_start, out.end, out.rpt_step, 0)
+            == 0
+        )
 
 
 def test_verify_time_datetime_before_start():
@@ -248,8 +253,11 @@ def test_verify_time_datetime_before_start():
     with Output(MODEL_WEIR_SETTING_PATH.replace("inp", "out")) as out:
         bad_dt = out.rpt_start
         with pytest.raises(OutputException) as exc:
-            Output.verify_time(bad_dt, out.times, out.rpt_start, out.end, out.rpt_step, 0)
+            Output.verify_time(
+                bad_dt, out.times, out.rpt_start, out.end, out.rpt_step, 0
+            )
         assert "does not exist in model output reporting time steps." in str(exc.value)
+
 
 def test_verify_time():
     # Produce the output file (simulation start != report start)
@@ -271,23 +279,39 @@ def test_verify_time():
 
         # Requesting the (non-inclusive) report start should fail with a clear message
         with pytest.raises(OutputException):
-            temp_out = out.node_series("J2", NodeAttribute.TOTAL_INFLOW, out.rpt_start, out.end)
+            temp_out = out.node_series(
+                "J2", NodeAttribute.TOTAL_INFLOW, out.rpt_start, out.end
+            )
 
         # verify_time returns indices for valid datetimes
-        assert Output.verify_time(out.times[0], out.times, out.rpt_start, out.end, out.rpt_step, 0) == 0
-        assert Output.verify_time(out.times[-1], out.times, out.rpt_start, out.end, out.rpt_step, 0) == len(out.times) - 1
+        assert (
+            Output.verify_time(
+                out.times[0], out.times, out.rpt_start, out.end, out.rpt_step, 0
+            )
+            == 0
+        )
+        assert (
+            Output.verify_time(
+                out.times[-1], out.times, out.rpt_start, out.end, out.rpt_step, 0
+            )
+            == len(out.times) - 1
+        )
 
         # Requesting the (non-inclusive) report start should fail with a clear message
         implied_report_start = out.times[0] - timedelta(seconds=out.rpt_step)
         with pytest.raises(OutputException) as exc:
-            Output.verify_time(implied_report_start, out.times, out.rpt_start, out.end, out.rpt_step, 0)
+            Output.verify_time(
+                implied_report_start, out.times, out.rpt_start, out.end, out.rpt_step, 0
+            )
         msg = str(exc.value).lower()
-        assert "does not exist" in msg #or "index 0" in msg
+        assert "does not exist" in msg  # or "index 0" in msg
 
         # Non-aligned datetime between start and first reporting time should fail
         bad_dt = implied_report_start + timedelta(seconds=1)
         with pytest.raises(OutputException):
-            Output.verify_time(bad_dt, out.times, out.rpt_start, out.end, out.rpt_step, 0)
+            Output.verify_time(
+                bad_dt, out.times, out.rpt_start, out.end, out.rpt_step, 0
+            )
 
 
 def test_verify_time_with_report_delay():
@@ -307,23 +331,39 @@ def test_verify_time_with_report_delay():
         # Non-inclusive start: index 0 == (report_start + report)
         assert out.times[0] == out.rpt_start + timedelta(seconds=out.rpt_step)
         assert out.times[-1] == out.end
-        
+
         # Requesting the (non-inclusive) report start should fail with a clear message
         with pytest.raises(OutputException):
-            temp_out = out.node_series("J2", NodeAttribute.TOTAL_INFLOW, out.rpt_start, out.end)
+            temp_out = out.node_series(
+                "J2", NodeAttribute.TOTAL_INFLOW, out.rpt_start, out.end
+            )
 
         # verify_time returns indices for valid datetimes
-        assert Output.verify_time(out.times[0], out.times, out.rpt_start, out.end, out.rpt_step, 0) == 0
-        assert Output.verify_time(out.times[-1], out.times, out.rpt_start, out.end, out.rpt_step, 0) == len(out.times) - 1
+        assert (
+            Output.verify_time(
+                out.times[0], out.times, out.rpt_start, out.end, out.rpt_step, 0
+            )
+            == 0
+        )
+        assert (
+            Output.verify_time(
+                out.times[-1], out.times, out.rpt_start, out.end, out.rpt_step, 0
+            )
+            == len(out.times) - 1
+        )
 
         # Requesting the (non-inclusive) report start should fail with a clear message
         implied_report_start = out.times[0] - timedelta(seconds=out.rpt_step)
         with pytest.raises(OutputException) as exc:
-            Output.verify_time(implied_report_start, out.times, out.rpt_start, out.end, out.rpt_step, 0)
+            Output.verify_time(
+                implied_report_start, out.times, out.rpt_start, out.end, out.rpt_step, 0
+            )
         msg = str(exc.value).lower()
-        assert "does not exist" in msg #or "index 0" in msg
+        assert "does not exist" in msg  # or "index 0" in msg
 
         # Non-aligned datetime between start and first reporting time should fail
         bad_dt = implied_report_start + timedelta(seconds=1)
         with pytest.raises(OutputException):
-            Output.verify_time(bad_dt, out.times, out.rpt_start, out.end, out.rpt_step, 0)
+            Output.verify_time(
+                bad_dt, out.times, out.rpt_start, out.end, out.rpt_step, 0
+            )

--- a/pyswmm/tests/test_output.py
+++ b/pyswmm/tests/test_output.py
@@ -19,6 +19,7 @@ from swmm.toolkit.shared_enum import (
     SystemAttribute,
 )
 from datetime import datetime
+from swmm.toolkit import output as tk_output
 
 
 def test_output_unknown_object_id():
@@ -153,3 +154,31 @@ def test_timeseries_abstraction():
         for attr in SystemAttribute:
             series = getattr(SystemSeries(out), attr.name.lower())
             assert len(series) == 3480
+
+
+def test_times_loaded_from_binary():
+    # Run the model to produce the .out
+    with Simulation(MODEL_WEIR_SETTING_PATH) as sim:
+        for step in sim:
+            pass
+
+    # Verify out.times equals toolkit-decoded date series
+    with Output(MODEL_WEIR_SETTING_PATH.replace("inp", "out")) as out:
+        raw = tk_output.get_date_series(out.handle, 0, out.period - 1)
+        decoded = [datetime(*tk_output.decode_date(d)[:6]).replace(microsecond=0) for d in raw]
+        assert out.times == decoded
+
+
+def test_verify_time_binary_search_datetime():
+    with Simulation(MODEL_WEIR_SETTING_PATH) as sim:
+        for step in sim:
+            pass
+
+    with Output(MODEL_WEIR_SETTING_PATH.replace("inp", "out")) as out:
+        # Pick a middle timestamp and ensure verify_time finds it
+        mid = len(out.times) // 2
+        dt = out.times[mid]
+        idx = Output.verify_time(dt, out.times, out.start, out.end, out.report, 0)
+        assert idx == mid
+        # None defaults to 0
+        assert Output.verify_time(None, out.times, out.start, out.end, out.report, 0) == 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Build dependencies
 #python
-julian>=0.14
+#julian>=0.14
 swmm-toolkit<=1.0.0
 packaging


### PR DESCRIPTION
This pull request improves the robustness and accuracy of the reporting timeline handling in the `Output` module, particularly around time validation and series extraction. The main focus is to harden the `verify_time()` method, ensure correct datetime bounds, and avoid rounding drift in reporting times. Additionally, regression tests have been added to cover these changes.

**Reporting timeline and time validation improvements:**

* Hardened the `Output.verify_time()` method to reject boolean indices, safely handle empty reporting timelines, and enforce datetime bounds against the configured start/end values. Also, switched to binary search for efficient datetime lookup.
* Changed internal reporting metadata: replaced `start` and `report` attributes with `rpt_start` and `rpt_step`, and now builds the reporting timeline from the binary output file to avoid rounding drift. The last timestamp is used as the reporting end. [[1]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L69-R70) [[2]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L181-R220) [[3]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L240-R272)

**Series and attribute extraction consistency:**

* Updated all series and attribute extraction methods (`subcatch_series`, `node_series`, `link_series`, `system_series`, and related result/attribute methods) to use the new reporting timeline attributes (`rpt_start`, `rpt_step`, etc.) for time validation and indexing. [[1]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L510-R559) [[2]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L602-R661) [[3]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L693-R762) [[4]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L781-R860) [[5]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L855-R925) [[6]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L895-R965) [[7]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L934-R1004) [[8]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L962-R1032) [[9]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L1002-R1072) [[10]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L1042-R1112) [[11]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L1079-R1149) [[12]](diffhunk://#diff-f19e015ce826fa6e5ce952f7f1891f3d13d84557d9250bd0e94137c756ac3a92L1121-R1191)

**Testing and documentation:**

* Added regression tests for `verify_time()` to cover start/end bound checks, empty time-list handling, and boolean index rejection.
* Updated `CHANGELOG.md` to document the above changes.

**Miscellaneous:**

* Bumped the package version to `2.1.1` in `pyswmm/__init__.py`.
* Added new test model path `MODEL_DELAYED_REPORT_PATH` in `pyswmm/tests/data/__init__.py`.